### PR TITLE
Use mmcv instead of mmcv-nighty

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,5 +1,5 @@
 matplotlib
-mmcv-nightly
+mmcv
 numpy
 opencv-contrib-python
 # need older pillow until torchvision is fixed


### PR DESCRIPTION
[mmcv-nighty](https://pypi.org/project/mmcv-nightly/) is the old version of mmcv.