### PR TITLE
Extract rgb frames without denseflow

### DIFF
--- a/docs/data_preparation.md
+++ b/docs/data_preparation.md
@@ -11,7 +11,7 @@ To make video decoding faster, we support several efficient video loading librar
 ## Supported Datasets
 
 The supported datasets are listed below.
-We provide shell scripts for data preparation under the path `$MMACTION/tools/data/`.
+We provide shell scripts for data preparation under the path `$MMACTION2/tools/data/`.
 To ease usage, we provide tutorials of data deployment for each dataset.
 
 - [UCF101](https://www.crcv.ucf.edu/data/UCF101.php): See [preparing_ucf101.md](/tools/data/ucf101/preparing_ucf101.md).
@@ -28,7 +28,7 @@ Now, you can switch to [getting_started.md](getting_started.md) to train and tes
 ## Getting Data
 
 The following guide is helpful when you want to experiment with custom dataset.
-Similar to the datasets stated above, it is recommended organizing in `$MMACTION/data/$DATASET`.
+Similar to the datasets stated above, it is recommended organizing in `$MMACTION2/data/$DATASET`.
 
 ### Prepare videos
 
@@ -67,10 +67,10 @@ python build_rawframes.py ${SRC_FOLDER} ${OUT_FOLDER} [--task ${TASK}] [--level 
 The recommended practice is
 
 1. set `$OUT_FOLDER` to be a folder located in SSD.
-2. symlink the link `$OUT_FOLDER` to `$MMACTION/data/$DATASET/rawframes`.
+2. symlink the link `$OUT_FOLDER` to `$MMACTION2/data/$DATASET/rawframes`.
 
 ```shell
-ln -s ${YOUR_FOLDER} $MMACTION/data/$DATASET/rawframes
+ln -s ${YOUR_FOLDER} $MMACTION2/data/$DATASET/rawframes
 ```
 
 ### Generate file list
@@ -78,7 +78,7 @@ ln -s ${YOUR_FOLDER} $MMACTION/data/$DATASET/rawframes
 We provide a convenient script to generate annotation file list. You can use the following command to extract frames.
 
 ```shell
-cd $MMACTION
+cd $MMACTION2
 python tools/data/build_file_list.py ${DATASET} ${SRC_FOLDER} [--rgb-prefix ${RGB_PREFIX}] \
     [--flow-x-prefix ${FLOW_X_PREFIX}] [--flow-y-prefix ${FLOW_Y_PREFIX}] [--num-split ${NUM_SPLIT}] \
     [--subset ${SUBSET}] [--level ${LEVEL}] [--format ${FORMAT}] [--out-root-path ${OUT_ROOT_PATH}] \
@@ -87,8 +87,8 @@ python tools/data/build_file_list.py ${DATASET} ${SRC_FOLDER} [--rgb-prefix ${RG
 
 - `DATASET`: Dataset to be prepared, e.g., `ucf101`, `kinetics400`, `thumos14`, `sthv1`, `sthv2`, etc.
 - `SRC_FOLDER`: Folder of the corresponding data format:
-  - "$MMACTION/data/$DATASET/rawframes" if `--format rawframes`.
-  - "$MMACTION/data/$DATASET/videos" if `--format videos`.
+  - "$MMACTION2/data/$DATASET/rawframes" if `--format rawframes`.
+  - "$MMACTION2/data/$DATASET/videos" if `--format videos`.
 - `RGB_PREFIX`: Name prefix of rgb frames.
 - `FLOW_X_PREFIX`: Name prefix of x flow frames.
 - `FLOW_Y_PREFIX`: Name prefix of y flow frames.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -5,7 +5,7 @@ For installation instructions, please see [install.md](install.md).
 
 ## Datasets
 
-It is recommended to symlink the dataset root to `$MMACTION/data`.
+It is recommended to symlink the dataset root to `$MMACTION2/data`.
 If your folder structure is different, you may need to change the corresponding paths in config files.
 
 ```

--- a/tools/data/activitynet/preparing_activitynet.md
+++ b/tools/data/activitynet/preparing_activitynet.md
@@ -2,7 +2,7 @@
 
 For basic dataset information, please refer to the official [website](http://activity-net.org/).
 Here, we use the ActivityNet rescaled feature provided in this [repo](https://github.com/wzmsltw/BSN-boundary-sensitive-network#code-and-data-preparation).
-Before we start, please make sure that current working directory is `$MMACTION/tools/data/activitynet/`.
+Before we start, please make sure that current working directory is `$MMACTION2/tools/data/activitynet/`.
 
 ## Step 1. Download Annotations
 First of all, you can run the following script to download annotation files.

--- a/tools/data/build_rawframes.py
+++ b/tools/data/build_rawframes.py
@@ -23,7 +23,7 @@ def extract_frame(vid_item, dev_id=0):
     """
     full_path, vid_path, vid_id, method, task = vid_item
     if ('/' in vid_path):
-        act_name = osp.split(osp.splitext(vid_path)[0])[0]
+        act_name = osp.basename(osp.dirname(vid_path))
         out_full_path = osp.join(args.out_dir, act_name)
     else:
         out_full_path = args.out_dir

--- a/tools/data/build_rawframes.py
+++ b/tools/data/build_rawframes.py
@@ -23,8 +23,8 @@ def extract_frame(vid_item, dev_id=0):
     """
     full_path, vid_path, vid_id, method, task = vid_item
     if ('/' in vid_path):
-        vid_name = vid_path.split('.')[0].split('/')[0]
-        out_full_path = osp.join(args.out_dir, vid_name)
+        act_name = osp.splitext(vid_path)[0].split('/')[0]
+        out_full_path = osp.join(args.out_dir, act_name)
     else:
         out_full_path = args.out_dir
 
@@ -32,7 +32,7 @@ def extract_frame(vid_item, dev_id=0):
         if args.use_opencv:
             # Not like using denseflow,
             # Use OpenCV will not make a sub directory with the video name
-            video_name = vid_path.split('.')[0].split('/')[-1]
+            video_name = osp.splitext(osp.basename(vid_path))[0]
             out_full_path = osp.join(out_full_path, video_name)
 
             vr = mmcv.VideoReader(full_path)

--- a/tools/data/build_rawframes.py
+++ b/tools/data/build_rawframes.py
@@ -23,7 +23,7 @@ def extract_frame(vid_item, dev_id=0):
     """
     full_path, vid_path, vid_id, method, task = vid_item
     if ('/' in vid_path):
-        act_name = osp.splitext(vid_path)[0].split('/')[0]
+        act_name = osp.split(osp.splitext(vid_path)[0])[0]
         out_full_path = osp.join(args.out_dir, act_name)
     else:
         out_full_path = args.out_dir

--- a/tools/data/kinetics400/extract_rgb_frames_opencv.sh
+++ b/tools/data/kinetics400/extract_rgb_frames_opencv.sh
@@ -1,0 +1,10 @@
+#! /usr/bin/bash env
+
+cd ../
+python build_rawframes.py ../../data/kinetics400/videos_train/ ../../data/kinetics400/rawframes_train/ --level 2  --ext mp4 --task rgb  --use-opencv
+echo "Raw frames (RGB only) generated for train set"
+
+python build_rawframes.py ../../data/kinetics400/videos_val/ ../../data/kinetics400/rawframes_val/ --level 2 --ext mp4 --task rgb  --use-opencv
+echo "Raw frames (RGB only) generated for val set"
+
+cd kinetics400/

--- a/tools/data/kinetics400/extract_rgb_frames_opencv.sh
+++ b/tools/data/kinetics400/extract_rgb_frames_opencv.sh
@@ -1,10 +1,10 @@
 #! /usr/bin/bash env
 
 cd ../
-python build_rawframes.py ../../data/kinetics400/videos_train/ ../../data/kinetics400/rawframes_train/ --level 2  --ext mp4 --task rgb  --use-opencv
+python build_rawframes.py ../../data/kinetics400/videos_train/ ../../data/kinetics400/rawframes_train/ --level 2  --ext mp4 --task rgb --new-width 340 --new-height 256 --use-opencv
 echo "Raw frames (RGB only) generated for train set"
 
-python build_rawframes.py ../../data/kinetics400/videos_val/ ../../data/kinetics400/rawframes_val/ --level 2 --ext mp4 --task rgb  --use-opencv
+python build_rawframes.py ../../data/kinetics400/videos_val/ ../../data/kinetics400/rawframes_val/ --level 2 --ext mp4 --task rgb --new-width 340 --new-height 256 --use-opencv
 echo "Raw frames (RGB only) generated for val set"
 
 cd kinetics400/

--- a/tools/data/kinetics400/preparing_kinetics400.md
+++ b/tools/data/kinetics400/preparing_kinetics400.md
@@ -69,7 +69,7 @@ If both are required, run the following script to extract frames.
 bash extract_frames.sh
 ```
 
-These two commands above can generate images with size 340x256, if you want to generate images with short edge 320 (320p),
+These three commands above can generate images with size 340x256, if you want to generate images with short edge 320 (320p),
 you can change the args `--new-width 340 --new-height 256` to `--new-short 320`.
 More details can be found in [data_preparation](/docs/data_preparation.md)
 

--- a/tools/data/kinetics400/preparing_kinetics400.md
+++ b/tools/data/kinetics400/preparing_kinetics400.md
@@ -51,10 +51,16 @@ mkdir /mnt/SSD/kinetics400_extracted_val/
 ln -s /mnt/SSD/kinetics400_extracted_val/ ../../../data/kinetics400/rawframes_val/
 ```
 
-If you didn't install dense_flow in the installation or only want to play with RGB frames (since extracting optical flow can be time-consuming), consider running the following script to extract **RGB-only** frames.
+If you only want to play with RGB frames (since extracting optical flow can be time-consuming), consider running the following script to extract **RGB-only** frames using denseflow.
 
 ```shell
 bash extract_rgb_frames.sh
+```
+
+If you didn't install denseflow, you can still extract RGB frames using OpenCV by the following script, but it will keep the original size of the images.
+
+```shell
+bash extract_rgb_frames_opencv.sh
 ```
 
 If both are required, run the following script to extract frames.

--- a/tools/data/kinetics400/preparing_kinetics400.md
+++ b/tools/data/kinetics400/preparing_kinetics400.md
@@ -1,7 +1,7 @@
 # Preparing Kinetics-400
 
 For basic dataset information, please refer to the official [website](https://deepmind.com/research/open-source/open-source-datasets/kinetics/).
-Before we start, please make sure that the directory is located at `$MMACTION/tools/data/kinetics400/`.
+Before we start, please make sure that the directory is located at `$MMACTION2/tools/data/kinetics400/`.
 
 ## Step 1. Prepare Annotations
 

--- a/tools/data/mit/extract_rgb_frames_opencv.sh
+++ b/tools/data/mit/extract_rgb_frames_opencv.sh
@@ -1,0 +1,10 @@
+#! /usr/bin/bash env
+
+cd ../
+python build_rawframes.py ../../data/mit/videos/training ../../data/mit/rawframes/training/ --level 2 --ext mp4 --task rgb --use-opencv
+echo "Raw frames (RGB only) generated for train set"
+
+python build_rawframes.py ../../data/mit/videos/validation ../../data/mit/rawframes/validation/ --level 2 --ext mp4 --task rgb --use-opencv
+echo "Raw frames (RGB only) generated for val set"
+
+cd mit/

--- a/tools/data/mit/preparing_mit.md
+++ b/tools/data/mit/preparing_mit.md
@@ -1,7 +1,7 @@
 # Preparing Moments in Time
 
 For basic dataset information, you can refer to the dataset [website](http://moments.csail.mit.edu/).
-Before we start, please make sure that the directory is located at `$MMACTION/tools/data/mit/`.
+Before we start, please make sure that the directory is located at `$MMACTION2/tools/data/mit/`.
 
 ## Step 1. Prepare Annotations and Videos
 

--- a/tools/data/mit/preparing_mit.md
+++ b/tools/data/mit/preparing_mit.md
@@ -17,10 +17,7 @@ This part is **optional** if you only want to use the video loader.
 
 Before extracting, please refer to [install.md](/docs/install.md) for installing [dense_flow](https://github.com/open-mmlab/denseflow).
 
-
-If you didn't install dense_flow in the installation or only want to play with RGB frames (since extracting optical flow can be time-consuming), consider running the following script to extract **RGB-only** frames.
-
-Fist, You can run the following script to soft link the extracted frames.
+If you have plenty of SSD space, then we recommend extracting frames there for better I/O performance. And you can run the following script to soft link the extracted frames.
 
 ```shell
 # execute these two line (Assume the SSD is mounted at "/mnt/SSD/")
@@ -28,8 +25,16 @@ mkdir /mnt/SSD/mit_extracted/
 ln -s /mnt/SSD/mit_extracted/ ../../../data/mit/rawframes
 ```
 
+If you only want to play with RGB frames (since extracting optical flow can be time-consuming), consider running the following script to extract **RGB-only** frames using denseflow.
+
 ```shell
 bash extract_rgb_frames.sh
+```
+
+If you didn't install denseflow, you can still extract RGB frames using OpenCV by the following script, but it will keep the original size of the images.
+
+```shell
+bash extract_rgb_frames_opencv.sh
 ```
 
 If both are required, run the following script to extract frames.

--- a/tools/data/mmit/extract_rgb_frames_opencv.sh
+++ b/tools/data/mmit/extract_rgb_frames_opencv.sh
@@ -1,0 +1,8 @@
+#! /usr/bin/bash env
+
+cd ../
+python build_rawframes.py ../../data/mmit/videos/ ../../data/mmit/rawframes/ --task rgb --level 2 --ext mp4 --use-opencv
+
+echo "Genearte raw frames (RGB only)"
+
+cd mmit/

--- a/tools/data/mmit/preparing_mmit.md
+++ b/tools/data/mmit/preparing_mmit.md
@@ -25,10 +25,16 @@ mkdir /mnt/SSD/mmit_extracted/
 ln -s /mnt/SSD/mmit_extracted/ ../../../data/mmit/rawframes
 ```
 
-If you didn't install dense_flow in the installation or only want to play with RGB frames (since extracting optical flow can be time-consuming), consider running the following script to extract **RGB-only** frames.
+If you only want to play with RGB frames (since extracting optical flow can be time-consuming), consider running the following script to extract **RGB-only** frames using denseflow.
 
 ```shell
 bash extract_rgb_frames.sh
+```
+
+If you didn't install denseflow, you can still extract RGB frames using OpenCV by the following script, but it will keep the original size of the images.
+
+```shell
+bash extract_rgb_frames_opencv.sh
 ```
 
 If both are required, run the following script to extract frames using "tvl1" algorithm.

--- a/tools/data/mmit/preparing_mmit.md
+++ b/tools/data/mmit/preparing_mmit.md
@@ -1,7 +1,7 @@
 # Preparing Multi-Moments in Time
 
 For basic dataset information, you can refer to the dataset [website](moments.csail.mit.edu).
-Before we start, please make sure that the directory is located at `$MMACTION/tools/data/mmit/`.
+Before we start, please make sure that the directory is located at `$MMACTION2/tools/data/mmit/`.
 
 ## Step 1. Prepare Annotations and Videos
 

--- a/tools/data/sthv1/extract_rgb_frames_opencv.sh
+++ b/tools/data/sthv1/extract_rgb_frames_opencv.sh
@@ -1,0 +1,7 @@
+#! /usr/bin/bash env
+
+cd ../
+python build_rawframes.py ../../data/sthv1/videos/ ../../data/sthv1/rawframes/ --task rgb --level 1  --ext webm  --use-opencv
+echo "Genearte raw frames (RGB only)"
+
+cd sthv1/

--- a/tools/data/sthv1/preparing_sthv1.md
+++ b/tools/data/sthv1/preparing_sthv1.md
@@ -33,11 +33,18 @@ mkdir /mnt/SSD/sthv1_extracted/
 ln -s /mnt/SSD/sthv1_extracted/ ../../../data/sthv1/rawframes
 ```
 
-If you didn't install dense_flow in the installation or only want to play with RGB frames (since extracting optical flow can be time-consuming), consider running the following script to extract **RGB-only** frames.
+If you only want to play with RGB frames (since extracting optical flow can be time-consuming), consider running the following script to extract **RGB-only** frames using denseflow.
 
 ```shell
 cd $MMACTION/tools/data/sthv1/
 bash extract_rgb_frames.sh
+```
+
+If you didn't install denseflow, you can still extract RGB frames using OpenCV by the following script, but it will keep the original size of the images.
+
+```shell
+cd $MMACTION/tools/data/sthv1/
+bash extract_rgb_frames_opencv.sh
 ```
 
 If both are required, run the following script to extract frames.

--- a/tools/data/sthv1/preparing_sthv1.md
+++ b/tools/data/sthv1/preparing_sthv1.md
@@ -1,20 +1,20 @@
 # Preparing Something-Something V1
 
 For basic dataset information, you can refer to the dataset [website](https://20bn.com/datasets/something-something/v1).
-Before we start, please make sure that the directory is located at `$MMACTION/tools/data/sthv1/`.
+Before we start, please make sure that the directory is located at `$MMACTION2/tools/data/sthv1/`.
 
 ## Step 1. Prepare Annotations
 
-First of all, you have to sign in and download annotations to `$MMACTION/data/sthv1/annotations` on the official [website](https://20bn.com/datasets/something-something/v1).
+First of all, you have to sign in and download annotations to `$MMACTION2/data/sthv1/annotations` on the official [website](https://20bn.com/datasets/something-something/v1).
 
 ## Step 2. Prepare Videos
 
-Then, you can download all data parts to `$MMACTION/data/sthv1/` and use the following command to extract.
+Then, you can download all data parts to `$MMACTION2/data/sthv1/` and use the following command to extract.
 
 ```shell
-cd $MMACTION/data/sthv1/
+cd $MMACTION2/data/sthv1/
 cat 20bn-something-something-v1-?? | tar zx
-cd $MMACTION/tools/data/sthv1/
+cd $MMACTION2/tools/data/sthv1/
 ```
 
 ## Step 3. Extract RGB and Flow
@@ -36,21 +36,21 @@ ln -s /mnt/SSD/sthv1_extracted/ ../../../data/sthv1/rawframes
 If you only want to play with RGB frames (since extracting optical flow can be time-consuming), consider running the following script to extract **RGB-only** frames using denseflow.
 
 ```shell
-cd $MMACTION/tools/data/sthv1/
+cd $MMACTION2/tools/data/sthv1/
 bash extract_rgb_frames.sh
 ```
 
 If you didn't install denseflow, you can still extract RGB frames using OpenCV by the following script, but it will keep the original size of the images.
 
 ```shell
-cd $MMACTION/tools/data/sthv1/
+cd $MMACTION2/tools/data/sthv1/
 bash extract_rgb_frames_opencv.sh
 ```
 
 If both are required, run the following script to extract frames.
 
 ```shell
-cd $MMACTION/tools/data/sthv1/
+cd $MMACTION2/tools/data/sthv1/
 bash extract_frames.sh
 ```
 
@@ -59,7 +59,7 @@ bash extract_frames.sh
 you can run the follow script to generate file list in the format of rawframes and videos.
 
 ```shell
-cd $MMACTION/tools/data/sthv1/
+cd $MMACTION2/tools/data/sthv1/
 bash generate_{rawframes, videos}_filelist.sh
 ```
 

--- a/tools/data/sthv2/extract_rgb_frames_opencv.sh
+++ b/tools/data/sthv2/extract_rgb_frames_opencv.sh
@@ -1,0 +1,7 @@
+#! /usr/bin/bash env
+
+cd ../
+python build_rawframes.py ../../data/sthv2/videos/ ../../data/sthv2/rawframes/ --task rgb --level 1 --ext webm --use-opencv
+echo "Genearte raw frames (RGB only)"
+
+cd sthv2/

--- a/tools/data/sthv2/preparing_sthv2.md
+++ b/tools/data/sthv2/preparing_sthv2.md
@@ -1,18 +1,18 @@
 # Preparing Something-Something V2
 
 For basic dataset information, you can refer to the dataset [website](https://20bn.com/datasets/something-something/v2).
-Before we start, please make sure that the directory is located at `$MMACTION/tools/data/sthv2/`.
+Before we start, please make sure that the directory is located at `$MMACTION2/tools/data/sthv2/`.
 
 ## Step 1. Prepare Annotations
 
-First of all, you have to sign in and download annotations to `$MMACTION/data/sthv2/annotations` on the official [website](https://20bn.com/datasets/something-something/v2).
+First of all, you have to sign in and download annotations to `$MMACTION2/data/sthv2/annotations` on the official [website](https://20bn.com/datasets/something-something/v2).
 
 ## Step 2. Prepare Videos
 
-Then, you can download all data parts to `$MMACTION/data/sthv2/` and use the following command to extract.
+Then, you can download all data parts to `$MMACTION2/data/sthv2/` and use the following command to extract.
 
 ```shell
-cd $MMACTION/data/sthv2/
+cd $MMACTION2/data/sthv2/
 cat 20bn-something-something-v2-?? | tar zx
 ```
 
@@ -35,21 +35,21 @@ ln -s /mnt/SSD/sthv2_extracted/ ../../../data/sthv2/rawframes
 If you only want to play with RGB frames (since extracting optical flow can be time-consuming), consider running the following script to extract **RGB-only** frames using denseflow.
 
 ```shell
-cd $MMACTION/tools/data/sthv2/
+cd $MMACTION2/tools/data/sthv2/
 bash extract_rgb_frames.sh
 ```
 
 If you didn't install denseflow, you can still extract RGB frames using OpenCV by the following script, but it will keep the original size of the images.
 
 ```shell
-cd $MMACTION/tools/data/sthv2/
+cd $MMACTION2/tools/data/sthv2/
 bash extract_rgb_frames_opencv.sh
 ```
 
 If both are required, run the following script to extract frames.
 
 ```shell
-cd $MMACTION/tools/data/sthv2/
+cd $MMACTION2/tools/data/sthv2/
 bash extract_frames.sh
 ```
 
@@ -58,7 +58,7 @@ bash extract_frames.sh
 you can run the follow script to generate file list in the format of rawframes and videos.
 
 ```shell
-cd $MMACTION/tools/data/sthv2/
+cd $MMACTION2/tools/data/sthv2/
 bash generate_{rawframes, videos}_filelist.sh
 ```
 

--- a/tools/data/sthv2/preparing_sthv2.md
+++ b/tools/data/sthv2/preparing_sthv2.md
@@ -32,11 +32,18 @@ mkdir /mnt/SSD/sthv2_extracted/
 ln -s /mnt/SSD/sthv2_extracted/ ../../../data/sthv2/rawframes
 ```
 
-If you didn't install dense_flow in the installation or only want to play with RGB frames (since extracting optical flow can be time-consuming), consider running the following script to extract **RGB-only** frames.
+If you only want to play with RGB frames (since extracting optical flow can be time-consuming), consider running the following script to extract **RGB-only** frames using denseflow.
 
 ```shell
 cd $MMACTION/tools/data/sthv2/
 bash extract_rgb_frames.sh
+```
+
+If you didn't install denseflow, you can still extract RGB frames using OpenCV by the following script, but it will keep the original size of the images.
+
+```shell
+cd $MMACTION/tools/data/sthv2/
+bash extract_rgb_frames_opencv.sh
 ```
 
 If both are required, run the following script to extract frames.

--- a/tools/data/thumos14/extract_rgb_frames_opencv.sh
+++ b/tools/data/thumos14/extract_rgb_frames_opencv.sh
@@ -1,0 +1,10 @@
+#! /usr/bin/bash env
+
+cd ../
+python build_rawframes.py ../../data/thumos14/videos/validation/ ../../data/thumos14/rawframes/validation/ --level 1 --ext mp4 --task rgb --use-opencv
+echo "Raw frames (RGB only) generated for val set"
+
+python build_rawframes.py ../../data/thumos14/videos/test/ ../../data/thumos14/rawframes/test/ --level 1 --ext mp4 --task rgb --use-opencv
+echo "Raw frames (RGB only) generated for test set"
+
+cd thumos14/

--- a/tools/data/thumos14/preparing_thumos14.md
+++ b/tools/data/thumos14/preparing_thumos14.md
@@ -1,14 +1,14 @@
 # Preparing THUMOS'14
 
 For basic dataset information, you can refer to the dataset [website](https://www.crcv.ucf.edu/THUMOS14/download.html).
-Before we start, please make sure that the directory is located at `$MMACTION/tools/data/thumos14/`.
+Before we start, please make sure that the directory is located at `$MMACTION2/tools/data/thumos14/`.
 
 ## Step 1. Prepare Annotations
 
 First of all, run the following script to prepare annotations.
 
 ```shell
-cd $MMACTION/tools/data/thumos14/
+cd $MMACTION2/tools/data/thumos14/
 bash download_annotations.sh
 ```
 
@@ -17,7 +17,7 @@ bash download_annotations.sh
 Then, you can run the following script to prepare videos.
 
 ```shell
-cd $MMACTION/tools/data/thumos14/
+cd $MMACTION2/tools/data/thumos14/
 bash download_videos.sh
 ```
 
@@ -40,21 +40,21 @@ ln -s /mnt/SSD/thumos14_extracted/ ../data/thumos14/rawframes/
 If you only want to play with RGB frames (since extracting optical flow can be time-consuming), consider running the following script to extract **RGB-only** frames using denseflow.
 
 ```shell
-cd $MMACTION/tools/data/thumos14/
+cd $MMACTION2/tools/data/thumos14/
 bash extract_rgb_frames.sh
 ```
 
 If you didn't install denseflow, you can still extract RGB frames using OpenCV by the following script, but it will keep the original size of the images.
 
 ```shell
-cd $MMACTION/tools/data/thumos14/
+cd $MMACTION2/tools/data/thumos14/
 bash extract_rgb_frames_opencv.sh
 ```
 
 If both are required, run the following script to extract frames.
 
 ```shell
-cd $MMACTION/tools/data/thumos14/
+cd $MMACTION2/tools/data/thumos14/
 bash extract_frames.sh tvl1
 ```
 
@@ -63,7 +63,7 @@ bash extract_frames.sh tvl1
 You can run the follow script to fetch pre-computed tag proposals.
 
 ```shell
-cd $MMACTION/tools/data/thumos14/
+cd $MMACTION2/tools/data/thumos14/
 bash fetch_tag_proposals.sh
 ```
 

--- a/tools/data/thumos14/preparing_thumos14.md
+++ b/tools/data/thumos14/preparing_thumos14.md
@@ -37,11 +37,18 @@ mkdir /mnt/SSD/thumos14_extracted/
 ln -s /mnt/SSD/thumos14_extracted/ ../data/thumos14/rawframes/
 ```
 
-If you didn't install dense_flow in the installation or only want to play with RGB frames (since extracting optical flow can be time-consuming), consider running the following script to extract **RGB-only** frames.
+If you only want to play with RGB frames (since extracting optical flow can be time-consuming), consider running the following script to extract **RGB-only** frames using denseflow.
 
 ```shell
 cd $MMACTION/tools/data/thumos14/
 bash extract_rgb_frames.sh
+```
+
+If you didn't install denseflow, you can still extract RGB frames using OpenCV by the following script, but it will keep the original size of the images.
+
+```shell
+cd $MMACTION/tools/data/thumos14/
+bash extract_rgb_frames_opencv.sh
 ```
 
 If both are required, run the following script to extract frames.

--- a/tools/data/ucf101/extract_rgb_frames_opencv.sh
+++ b/tools/data/ucf101/extract_rgb_frames_opencv.sh
@@ -1,0 +1,7 @@
+#! /usr/bin/bash env
+
+cd ../
+python build_rawframes.py ../../data/ucf101/videos/ ../../data/ucf101/rawframes/ --task rgb --level 2 --ext avi --use-opencv
+echo "Genearte raw frames (RGB only)"
+
+cd ucf101/

--- a/tools/data/ucf101/preparing_ucf101.md
+++ b/tools/data/ucf101/preparing_ucf101.md
@@ -1,7 +1,7 @@
 # Preparing UCF-101
 
 For basic dataset information, you can refer to the dataset [website](https://www.crcv.ucf.edu/data/UCF101.php).
-Before we start, please make sure that the directory is located at `$MMACTION/tools/data/ucf101/`.
+Before we start, please make sure that the directory is located at `$MMACTION2/tools/data/ucf101/`.
 
 ## Step 1. Prepare Annotations
 

--- a/tools/data/ucf101/preparing_ucf101.md
+++ b/tools/data/ucf101/preparing_ucf101.md
@@ -35,10 +35,16 @@ mkdir /mnt/SSD/ucf101_extracted/
 ln -s /mnt/SSD/ucf101_extracted/ ../../../data/ucf101/rawframes
 ```
 
-If you didn't install dense_flow in the installation or only want to play with RGB frames (since extracting optical flow can be time-consuming), consider running the following script to extract **RGB-only** frames.
+If you only want to play with RGB frames (since extracting optical flow can be time-consuming), consider running the following script to extract **RGB-only** frames using denseflow.
 
 ```shell
 bash extract_rgb_frames.sh
+```
+
+If you didn't install denseflow, you can still extract RGB frames using OpenCV by the following script, but it will keep the original size of the images.
+
+```shell
+bash extract_rgb_frames_opencv.sh
 ```
 
 If both are required, run the following script to extract frames using "tvl1" algorithm.


### PR DESCRIPTION
1. Add `--use-opencv` args in `build_rawframes.py` to extract rgb rawframes by OpenCV instead of denseflow
2. Rename sth to MMACTION2