### PR TITLE
Add ColorJitter augmentation

### DIFF
--- a/mmaction/datasets/pipelines/__init__.py
+++ b/mmaction/datasets/pipelines/__init__.py
@@ -1,6 +1,7 @@
-from .augmentations import (CenterCrop, Flip, Fuse, MultiGroupCrop,
-                            MultiScaleCrop, Normalize, RandomCrop,
-                            RandomResizedCrop, Resize, TenCrop, ThreeCrop)
+from .augmentations import (CenterCrop, ColorJitter, Flip, Fuse,
+                            MultiGroupCrop, MultiScaleCrop, Normalize,
+                            RandomCrop, RandomResizedCrop, Resize, TenCrop,
+                            ThreeCrop)
 from .compose import Compose
 from .formating import (Collect, FormatShape, ImageToTensor, ToDataContainer,
                         ToTensor, Transpose)
@@ -19,5 +20,5 @@ __all__ = [
     'Collect', 'FormatShape', 'Compose', 'ToTensor', 'ToDataContainer',
     'GenerateLocalizationLabels', 'LoadLocalizationFeature', 'LoadProposals',
     'DecordInit', 'OpenCVInit', 'PyAVInit', 'SampleProposalFrames',
-    'UntrimmedSampleFrames', 'RawFrameDecode'
+    'UntrimmedSampleFrames', 'RawFrameDecode', 'ColorJitter'
 ]

--- a/mmaction/datasets/pipelines/augmentations.py
+++ b/mmaction/datasets/pipelines/augmentations.py
@@ -697,6 +697,116 @@ class Normalize(object):
 
 
 @PIPELINES.register_module()
+class ColorJitter(object):
+    """
+
+    """
+
+    def __init__(self,
+                 color_space_aug=False,
+                 alphastd=0.1,
+                 eigval=None,
+                 eigvec=None):
+        if eigval is None:
+            # note that the data range should be [0, 255]
+            self.eigval = np.array([55.46, 4.794, 1.148])
+        else:
+            self.eigval = eigval
+
+        if eigvec is None:
+            self.eigvec = np.array([[-0.5675, 0.7192, 0.4009],
+                                    [-0.5808, -0.0045, -0.8140],
+                                    [-0.5836, -0.6948, 0.4203]])
+        else:
+            self.eigvec = eigvec
+
+        self.alphastd = alphastd
+        self.color_space_aug = color_space_aug
+
+    @staticmethod
+    def brightnetss(imgs, delta):
+        if random.uniform(0, 1) > 0.5:
+            delta = np.array(delta).astype(np.float32)
+            imgs = imgs + delta
+        return imgs
+
+    @staticmethod
+    def contrast(imgs, alpha):
+        if random.uniform(0, 1) > 0.5:
+            alpha = np.array(alpha).astype(np.float32)
+            imgs = imgs * alpha
+        return imgs
+
+    @staticmethod
+    def saturation(imgs, alpha):
+        if random.uniform(0, 1) > 0.5:
+            gray = imgs * np.array([0.114, 0.587, 0.299]).astype(np.float32)
+            gray = np.sum(gray, 2, keepdims=True)
+            gray *= (1.0 - alpha)
+            imgs = imgs * alpha
+            imgs = imgs + gray
+        return imgs
+
+    @staticmethod
+    def hue(img, alpha):
+        if random.uniform(0, 1) > 0.5:
+            u = np.cos(alpha * np.pi)
+            w = np.sin(alpha * np.pi)
+            bt = np.array([[1.0, 0.0, 0.0], [0.0, u, -w], [0.0, w, u]])
+            tyiq = np.array([[0.299, 0.587, 0.114], [0.596, -0.274, -0.321],
+                             [0.211, -0.523, 0.311]])
+            ityiq = np.array([[1.0, 0.956, 0.621], [1.0, -0.272, -0.647],
+                              [1.0, -1.107, 1.705]])
+            t = np.dot(np.dot(ityiq, bt), tyiq).T
+            t = np.array(t).astype(np.float32)
+            t = np.flip(t)
+            img = np.dot(img, t)
+        return img
+
+    def __call__(self, results):
+        imgs = results['imgs']
+        out = []
+        if self.color_space_aug:
+            bright_delta = np.random.uniform(-32, 32)
+            contrast_alpha = np.random.uniform(0.6, 1.4)
+            saturation_alpha = np.random.uniform(0.6, 1.4)
+            hue_alpha = random.uniform(-18, 18)
+            for img in imgs:
+                img = self.brightnetss(img, delta=bright_delta)
+                if random.uniform(0, 1) > 0.5:
+                    img = self.contrast(img, alpha=contrast_alpha)
+                    img = self.saturation(img, alpha=saturation_alpha)
+                    img = self.hue(img, alpha=hue_alpha)
+                else:
+                    img = self.saturation(img, alpha=saturation_alpha)
+                    img = self.hue(img, alpha=hue_alpha)
+                    img = self.contrast(img, alpha=contrast_alpha)
+                out.append(img)
+        else:
+            out = imgs
+        alpha = np.random.normal(0, self.alphastd, size=(3, ))
+        rgb = np.array(np.dot(self.eigvec * alpha,
+                              self.eigval)).astype(np.float32)
+        rgb = np.expand_dims(np.expand_dims(rgb, 0), 0)
+
+        results['imgs'] = [img + rgb for img in out]
+        results['eigval'] = self.eigval
+        results['eigvec'] = self.eigvec
+        results['alphastd'] = self.alphastd
+        results['color_space_aug'] = self.color_space_aug
+
+        return results
+
+    def __repr__(self):
+        repr_str = (f'{self.__class__.__name__}('
+                    f'color_space_aug={self.color_space_aug}, '
+                    f'alphastd={self.alphastd}, '
+                    f'eigval={self.eigval}, '
+                    f'eigvec={self.eigvec})')
+        return repr_str
+
+
+@PIPELINES.register_module()
 class CenterCrop(object):
     """Crop the center area from images.
 

--- a/mmaction/datasets/pipelines/augmentations.py
+++ b/mmaction/datasets/pipelines/augmentations.py
@@ -713,9 +713,13 @@ class ColorJitter(object):
         color_space_aug (bool): Whether to apply color space augmentations. If
             specified, it will change the brightness, contrast, saturation and
             hue of images. Default: False.
-        alpha_std (bool): Std in a normal Gaussian distribution of the alpha.
-
-
+        alpha_std (float): Std in the normal Gaussian distribution of alpha.
+        eig_val (np.ndarray | None): Eigenvalues of [1 x 3] size for RGB
+            channel jitter. If set to None, it will use the default
+            eigenvalues. Default: None.
+        eig_vec (np.ndarray | None): Eigenvectors of [3 x 3] size for RGB
+            channel jitter. If set to None, it will use the default
+            eigenvectors. Default: None.
     """
 
     def __init__(self,
@@ -741,6 +745,7 @@ class ColorJitter(object):
 
     @staticmethod
     def brightnetss(imgs, delta):
+        """Brightness distortion."""
         if random.uniform(0, 1) > 0.5:
             delta = np.array(delta).astype(np.float32)
             imgs = imgs + delta
@@ -748,6 +753,7 @@ class ColorJitter(object):
 
     @staticmethod
     def contrast(imgs, alpha):
+        """Contrast distortion"""
         if random.uniform(0, 1) > 0.5:
             alpha = np.array(alpha).astype(np.float32)
             imgs = imgs * alpha
@@ -755,6 +761,7 @@ class ColorJitter(object):
 
     @staticmethod
     def saturation(imgs, alpha):
+        """Saturation distortion."""
         if random.uniform(0, 1) > 0.5:
             gray = imgs * np.array([0.114, 0.587, 0.299]).astype(np.float32)
             gray = np.sum(gray, 2, keepdims=True)
@@ -765,6 +772,7 @@ class ColorJitter(object):
 
     @staticmethod
     def hue(img, alpha):
+        """Hue distortion"""
         if random.uniform(0, 1) > 0.5:
             u = np.cos(alpha * np.pi)
             w = np.sin(alpha * np.pi)
@@ -775,6 +783,7 @@ class ColorJitter(object):
                               [1.0, -1.107, 1.705]])
             t = np.dot(np.dot(ityiq, bt), tyiq).T
             t = np.array(t).astype(np.float32)
+            # Here we use np.flip to suit our RGB images cases.
             t = np.flip(t)
             img = np.dot(img, t)
         return img

--- a/mmaction/datasets/pipelines/augmentations.py
+++ b/mmaction/datasets/pipelines/augmentations.py
@@ -698,7 +698,7 @@ class Normalize(object):
 
 @PIPELINES.register_module()
 class ColorJitter(object):
-    """Randomly change the brightness, contrast, saturation and hue of images,
+    """Randomly distort the brightness, contrast, saturation and hue of images,
     and add PCA based noise into images.
 
     Code Reference:
@@ -835,9 +835,10 @@ class ColorJitter(object):
             contrast_alpha = np.random.uniform(0.6, 1.4)
             saturation_alpha = np.random.uniform(0.6, 1.4)
             hue_alpha = np.random.uniform(-18, 18)
+            jitter_coin = np.random.uniform(0, 1)
             for img in imgs:
                 img = self.brightness(img, delta=bright_delta)
-                if np.random.uniform(0, 1) > 0.5:
+                if jitter_coin > 0.5:
                     img = self.contrast(img, alpha=contrast_alpha)
                     img = self.saturation(img, alpha=saturation_alpha)
                     img = self.hue(img, alpha=hue_alpha)

--- a/tests/test_data/test_augmentations.py
+++ b/tests/test_data/test_augmentations.py
@@ -3,10 +3,10 @@ import copy
 import mmcv
 import numpy as np
 import pytest
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 # yapf: disable
-from mmaction.datasets.pipelines import (CenterCrop, Flip, Fuse,
+from mmaction.datasets.pipelines import (CenterCrop, ColorJitter, Flip, Fuse,
                                          MultiGroupCrop, MultiScaleCrop,
                                          Normalize, RandomCrop,
                                          RandomResizedCrop, Resize, TenCrop,
@@ -797,6 +797,60 @@ class TestAugumentations(object):
             f'(mean={np.array([123.675, 116.28, 103.53])}, ' +
             f'std={np.array([58.395, 57.12, 57.375])}, to_bgr={True}, '
             f'adjust_magnitude={False})')
+
+    def test_color_jitter(self):
+        imgs = list(np.random.rand(3, 240, 320, 3))
+        results = dict(imgs=imgs)
+
+        eig_val = np.array([55.46, 4.794, 1.148])
+        eig_vec = np.array([[-0.5675, 0.7192, 0.4009],
+                            [-0.5808, -0.0045, -0.8140],
+                            [-0.5836, -0.6948, 0.4203]])
+
+        color_jitter = ColorJitter()
+        assert_array_equal(color_jitter.eig_val, eig_val)
+        assert_array_equal(color_jitter.eig_vec, eig_vec)
+        assert color_jitter.alpha_std == 0.1
+        assert color_jitter.color_space_aug is False
+        color_jitter_results = color_jitter(results)
+        target_keys = [
+            'imgs', 'eig_val', 'eig_vec', 'alpha_std', 'color_space_aug'
+        ]
+        assert self.check_keys_contain(color_jitter_results.keys(),
+                                       target_keys)
+        assert np.shape(color_jitter_results['imgs']) == (3, 240, 320, 3)
+        assert_array_equal(color_jitter_results['eig_val'], eig_val)
+        assert_array_equal(color_jitter_results['eig_vec'], eig_vec)
+        assert color_jitter_results['alpha_std'] == 0.1
+        assert color_jitter_results['color_space_aug'] is False
+
+        custom_eig_val = np.ones(3, )
+        custom_eig_vec = np.ones((3, 3))
+
+        imgs = list(np.random.rand(3, 240, 320, 3))
+        results = dict(imgs=imgs)
+        custom_color_jitter = ColorJitter(True, 0.5, custom_eig_val,
+                                          custom_eig_vec)
+        assert_array_equal(color_jitter.eig_val, eig_val)
+        assert_array_equal(color_jitter.eig_vec, eig_vec)
+        assert custom_color_jitter.alpha_std == 0.5
+        assert custom_color_jitter.color_space_aug is True
+        custom_color_jitter_results = custom_color_jitter(results)
+        assert np.shape(custom_color_jitter_results['imgs']) == (3, 240, 320,
+                                                                 3)
+        assert_array_equal(custom_color_jitter_results['eig_val'],
+                           custom_eig_val)
+        assert_array_equal(custom_color_jitter_results['eig_vec'],
+                           custom_eig_vec)
+        assert custom_color_jitter_results['alpha_std'] == 0.5
+        assert custom_color_jitter_results['color_space_aug'] is True
+
+        color_jitter = ColorJitter()
+        assert repr(color_jitter) == (f'{color_jitter.__class__.__name__}('
+                                      f'color_space_aug={False}, '
+                                      f'alpha_std={0.1}, '
+                                      f'eig_val={eig_val}, '
+                                      f'eig_vec={eig_vec})')
 
     def test_center_crop(self):
         with pytest.raises(TypeError):


### PR DESCRIPTION
This pr adds ColorJitter augmentation which includes distorting the brightness, contrast, saturation and hue of images, adding PCA bias to images  . It refers from [mxnet](https://gluon-cv.mxnet.io/_modules/gluoncv/data/transforms/experimental/image.html) and [gluon](https://mxnet.apache.org/api/python/docs/_modules/mxnet/image/image.html#LightingAug).

And I found [TPN repo](https://github.com/decisionforce/TPN/blob/master/mmaction/datasets/transforms.py#L33-L118) also used those for reference but didn't convert the image from BGR to RGB, which may be not correct.

Our codebase the RGB images as input, same with mxnet and gluon.