### PR TITLE
[Bug Fix] Fix a bug caused by start_index when using videos

### DIFF
--- a/configs/recognition/i3d/i3d_r50_video_32x2x1_100e_kinetics400_rgb.py
+++ b/configs/recognition/i3d/i3d_r50_video_32x2x1_100e_kinetics400_rgb.py
@@ -31,7 +31,12 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_bgr=False)
 train_pipeline = [
     dict(type='DecordInit'),
-    dict(type='SampleFrames', clip_len=32, frame_interval=2, num_clips=1),
+    dict(
+        type='SampleFrames',
+        clip_len=32,
+        frame_interval=2,
+        num_clips=1,
+        start_index=0),
     dict(type='DecordDecode'),
     dict(type='Resize', scale=(-1, 256)),
     dict(
@@ -54,6 +59,7 @@ val_pipeline = [
         clip_len=32,
         frame_interval=2,
         num_clips=1,
+        start_index=0,
         test_mode=True),
     dict(type='DecordDecode'),
     dict(type='Resize', scale=(-1, 256)),
@@ -71,6 +77,7 @@ test_pipeline = [
         clip_len=32,
         frame_interval=2,
         num_clips=10,
+        start_index=0,
         test_mode=True),
     dict(type='DecordDecode'),
     dict(type='Resize', scale=(-1, 256)),

--- a/configs/recognition/i3d/i3d_r50_video_inference_32x2x1_100e_kinetics400_rgb.py
+++ b/configs/recognition/i3d/i3d_r50_video_inference_32x2x1_100e_kinetics400_rgb.py
@@ -30,6 +30,7 @@ test_pipeline = [
         clip_len=32,
         frame_interval=2,
         num_clips=1,
+        start_index=0,
         test_mode=True),
     dict(type='DecordDecode'),
     dict(type='Resize', scale=(-1, 256)),

--- a/configs/recognition/r2plus1d/r2plus1d_r34_video_8x8x1_180e_kinetics400_rgb.py
+++ b/configs/recognition/r2plus1d/r2plus1d_r34_video_8x8x1_180e_kinetics400_rgb.py
@@ -38,7 +38,12 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_bgr=False)
 train_pipeline = [
     dict(type='DecordInit'),
-    dict(type='SampleFrames', clip_len=8, frame_interval=8, num_clips=1),
+    dict(
+        type='SampleFrames',
+        clip_len=8,
+        frame_interval=8,
+        num_clips=1,
+        start_index=0),
     dict(type='DecordDecode'),
     dict(type='Resize', scale=(-1, 256)),
     dict(type='RandomResizedCrop'),
@@ -56,6 +61,7 @@ val_pipeline = [
         clip_len=8,
         frame_interval=8,
         num_clips=1,
+        start_index=0,
         test_mode=True),
     dict(type='DecordDecode'),
     dict(type='Resize', scale=(-1, 256)),
@@ -73,6 +79,7 @@ test_pipeline = [
         clip_len=8,
         frame_interval=8,
         num_clips=10,
+        start_index=0,
         test_mode=True),
     dict(type='DecordDecode'),
     dict(type='Resize', scale=(-1, 256)),

--- a/configs/recognition/r2plus1d/r2plus1d_r34_video_inference_8x8x1_180e_kinetics400_rgb.py
+++ b/configs/recognition/r2plus1d/r2plus1d_r34_video_inference_8x8x1_180e_kinetics400_rgb.py
@@ -38,6 +38,7 @@ test_pipeline = [
         clip_len=8,
         frame_interval=8,
         num_clips=10,
+        start_index=0,
         test_mode=True),
     dict(type='DecordDecode'),
     dict(type='Resize', scale=(-1, 256)),

--- a/configs/recognition/slowfast/slowfast_r50_video_4x16x1_256e_kinetics400_rgb.py
+++ b/configs/recognition/slowfast/slowfast_r50_video_4x16x1_256e_kinetics400_rgb.py
@@ -45,7 +45,12 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_bgr=False)
 train_pipeline = [
     dict(type='DecordInit'),
-    dict(type='SampleFrames', clip_len=32, frame_interval=2, num_clips=1),
+    dict(
+        type='SampleFrames',
+        clip_len=32,
+        frame_interval=2,
+        num_clips=1,
+        start_index=0),
     dict(type='DecordDecode'),
     dict(type='Resize', scale=(-1, 256)),
     dict(type='RandomResizedCrop'),
@@ -63,6 +68,7 @@ val_pipeline = [
         clip_len=32,
         frame_interval=2,
         num_clips=1,
+        start_index=0,
         test_mode=True),
     dict(type='DecordDecode'),
     dict(type='Resize', scale=(-1, 256)),
@@ -80,6 +86,7 @@ test_pipeline = [
         clip_len=32,
         frame_interval=2,
         num_clips=10,
+        start_index=0,
         test_mode=True),
     dict(type='DecordDecode'),
     dict(type='Resize', scale=(-1, 256)),

--- a/configs/recognition/slowfast/slowfast_r50_video_inference_4x16x1_256e_kinetics400_rgb.py
+++ b/configs/recognition/slowfast/slowfast_r50_video_inference_4x16x1_256e_kinetics400_rgb.py
@@ -48,6 +48,7 @@ test_pipeline = [
         clip_len=32,
         frame_interval=2,
         num_clips=10,
+        start_index=0,
         test_mode=True),
     dict(type='DecordDecode'),
     dict(type='Resize', scale=(-1, 256)),

--- a/configs/recognition/slowonly/slowonly_r50_video_4x16x1_256e_kinetics400_rgb.py
+++ b/configs/recognition/slowonly/slowonly_r50_video_4x16x1_256e_kinetics400_rgb.py
@@ -28,7 +28,12 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_bgr=False)
 train_pipeline = [
     dict(type='DecordInit'),
-    dict(type='SampleFrames', clip_len=4, frame_interval=16, num_clips=1),
+    dict(
+        type='SampleFrames',
+        clip_len=4,
+        frame_interval=16,
+        num_clips=1,
+        start_index=0),
     dict(type='DecordDecode'),
     dict(type='Resize', scale=(-1, 256)),
     dict(type='RandomResizedCrop'),
@@ -46,6 +51,7 @@ val_pipeline = [
         clip_len=4,
         frame_interval=16,
         num_clips=1,
+        start_index=0,
         test_mode=True),
     dict(type='DecordDecode'),
     dict(type='Resize', scale=(-1, 256)),
@@ -63,6 +69,7 @@ test_pipeline = [
         clip_len=4,
         frame_interval=16,
         num_clips=10,
+        start_index=0,
         test_mode=True),
     dict(type='DecordDecode'),
     dict(type='Resize', scale=(-1, 256)),

--- a/configs/recognition/slowonly/slowonly_r50_video_inference_4x16x1_256e_kinetics400_rgb.py
+++ b/configs/recognition/slowonly/slowonly_r50_video_inference_4x16x1_256e_kinetics400_rgb.py
@@ -28,6 +28,7 @@ test_pipeline = [
         clip_len=4,
         frame_interval=16,
         num_clips=10,
+        start_index=0,
         test_mode=True),
     dict(type='DecordDecode'),
     dict(type='Resize', scale=(-1, 256)),

--- a/configs/recognition/tsm/tsm_r50_video_1x1x8_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsm/tsm_r50_video_1x1x8_100e_kinetics400_rgb.py
@@ -30,7 +30,12 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_bgr=False)
 train_pipeline = [
     dict(type='DecordInit'),
-    dict(type='SampleFrames', clip_len=1, frame_interval=1, num_clips=8),
+    dict(
+        type='SampleFrames',
+        clip_len=1,
+        frame_interval=1,
+        num_clips=8,
+        start_index=0),
     dict(type='DecordDecode'),
     dict(type='Resize', scale=(-1, 256)),
     dict(
@@ -54,6 +59,7 @@ val_pipeline = [
         clip_len=1,
         frame_interval=1,
         num_clips=8,
+        start_index=0,
         test_mode=True),
     dict(type='DecordDecode'),
     dict(type='Resize', scale=(-1, 256)),
@@ -71,6 +77,7 @@ test_pipeline = [
         clip_len=1,
         frame_interval=1,
         num_clips=8,
+        start_index=0,
         test_mode=True),
     dict(type='DecordDecode'),
     dict(type='Resize', scale=(-1, 256)),

--- a/configs/recognition/tsm/tsm_r50_video_inference_1x1x8_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsm/tsm_r50_video_inference_1x1x8_100e_kinetics400_rgb.py
@@ -30,6 +30,7 @@ test_pipeline = [
         clip_len=1,
         frame_interval=1,
         num_clips=8,
+        start_index=0,
         test_mode=True),
     dict(type='DecordDecode'),
     dict(type='Resize', scale=(-1, 256)),

--- a/configs/recognition/tsn/tsn_r50_video_1x1x8_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsn/tsn_r50_video_1x1x8_100e_kinetics400_rgb.py
@@ -28,7 +28,12 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_bgr=False)
 train_pipeline = [
     dict(type='DecordInit'),
-    dict(type='SampleFrames', clip_len=1, frame_interval=1, num_clips=8),
+    dict(
+        type='SampleFrames',
+        clip_len=1,
+        frame_interval=1,
+        num_clips=8,
+        start_index=0),
     dict(type='DecordDecode'),
     dict(
         type='MultiScaleCrop',
@@ -50,6 +55,7 @@ val_pipeline = [
         clip_len=1,
         frame_interval=1,
         num_clips=8,
+        start_index=0,
         test_mode=True),
     dict(type='DecordDecode'),
     dict(type='Resize', scale=(-1, 256)),
@@ -67,6 +73,7 @@ test_pipeline = [
         clip_len=1,
         frame_interval=1,
         num_clips=25,
+        start_index=0,
         test_mode=True),
     dict(type='DecordDecode'),
     dict(type='Resize', scale=(-1, 256)),

--- a/configs/recognition/tsn/tsn_r50_video_dense_1x1x8_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsn/tsn_r50_video_dense_1x1x8_100e_kinetics400_rgb.py
@@ -28,7 +28,12 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_bgr=False)
 train_pipeline = [
     dict(type='DecordInit'),
-    dict(type='DenseSampleFrames', clip_len=1, frame_interval=1, num_clips=8),
+    dict(
+        type='DenseSampleFrames',
+        clip_len=1,
+        frame_interval=1,
+        num_clips=8,
+        start_index=0),
     dict(type='DecordDecode'),
     dict(
         type='MultiScaleCrop',
@@ -50,6 +55,7 @@ val_pipeline = [
         clip_len=1,
         frame_interval=1,
         num_clips=8,
+        start_index=0,
         test_mode=True),
     dict(type='DecordDecode'),
     dict(type='Resize', scale=(-1, 256)),
@@ -67,6 +73,7 @@ test_pipeline = [
         clip_len=1,
         frame_interval=1,
         num_clips=25,
+        start_index=0,
         test_mode=True),
     dict(type='DecordDecode'),
     dict(type='Resize', scale=(-1, 256)),

--- a/configs/recognition/tsn/tsn_r50_video_inference_1x1x3_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsn/tsn_r50_video_inference_1x1x3_100e_kinetics400_rgb.py
@@ -27,6 +27,7 @@ test_pipeline = [
         clip_len=1,
         frame_interval=1,
         num_clips=25,
+        start_index=0,
         test_mode=True),
     dict(type='DecordDecode'),
     dict(type='Resize', scale=(-1, 256)),

--- a/mmaction/datasets/pipelines/loading.py
+++ b/mmaction/datasets/pipelines/loading.py
@@ -24,7 +24,9 @@ class SampleFrames(object):
             Default: 1.
         num_clips (int): Number of clips to be sampled. Default: 1.
         start_index (int): Specify a start index for frames in consideration of
-            different filename format. Default: 1.
+            different filename format. However, when taking videos as input,
+            it should be set to 0, since frames loaded from videos count
+            from 0. Default: 1.
         temporal_jitter (bool): Whether to apply temporal jittering.
             Default: False.
         twice_sample (bool): Whether to use twice sample when testing.

--- a/mmaction/datasets/pipelines/loading.py
+++ b/mmaction/datasets/pipelines/loading.py
@@ -57,8 +57,6 @@ class SampleFrames(object):
         self.test_mode = test_mode
         assert self.out_of_bound_opt in ['loop', 'repeat_last']
 
-        assert self.out_of_bound_opt in ['loop', 'repeat_last']
-
     def _get_train_clips(self, num_frames):
         """Get clip offsets in train mode.
 


### PR DESCRIPTION
`start_index` is used in `SampleFrames` to specify a start index for frames in consideration of different filename format in rawframes. But when taking videos as input, the `start_index` should be set to 0, since the frames loaded from videos are stored in a list, which counts from 0.