### PR TITLE
correct the sthv1/sthv2 rawframes filelist generate command

### DIFF
--- a/tools/data/sthv1/generate_rawframes_filelist.sh
+++ b/tools/data/sthv1/generate_rawframes_filelist.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 cd ../../../
-PYTHONPATH=. python tools/data/build_file_list.py sthv1 data/sthv1/rawframes/ --num-split 1 --level 1 --subset train --format rawframe --shuffle
-PYTHONPATH=. python tools/data/build_file_list.py sthv1 data/sthv1/rawframes/ --num-split 1 --level 1 --subset val --format rawframe --shuffle
+PYTHONPATH=. python tools/data/build_file_list.py sthv1 data/sthv1/rawframes/ --num-split 1 --level 1 --subset train --format rawframes --shuffle
+PYTHONPATH=. python tools/data/build_file_list.py sthv1 data/sthv1/rawframes/ --num-split 1 --level 1 --subset val --format rawframes --shuffle
 echo "Filelist for rawframes generated."
 
 cd tools/data/sthv1/

--- a/tools/data/sthv2/generate_rawframes_filelist.sh
+++ b/tools/data/sthv2/generate_rawframes_filelist.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 cd ../../../
-PYTHONPATH=. python tools/data/build_file_list.py sthv2 data/sthv2/rawframes/ --num-split 1 --level 1 --subset train --format rawframe --shuffle
-PYTHONPATH=. python tools/data/build_file_list.py sthv2 data/sthv2/rawframes/ --num-split 1 --level 1 --subset val --format rawframe --shuffle
+PYTHONPATH=. python tools/data/build_file_list.py sthv2 data/sthv2/rawframes/ --num-split 1 --level 1 --subset train --format rawframes --shuffle
+PYTHONPATH=. python tools/data/build_file_list.py sthv2 data/sthv2/rawframes/ --num-split 1 --level 1 --subset val --format rawframes --shuffle
 echo "Filelist for rawframes generated."
 
 cd tools/data/sthv2/


### PR DESCRIPTION
   tools/data/build_file_list.py only support two format ['rawframes', 'videos'], add missing 's' for the sthv1/sthv2 rawframes filelist generate command.
`parser.add_argument(
        '--format',
        type=str,
        default='rawframes',
        choices=['rawframes', 'videos'],
        help='data format')`