### PR TITLE
use `xxInit()` method to get total_frames

### DIFF
--- a/mmaction/datasets/pipelines/loading.py
+++ b/mmaction/datasets/pipelines/loading.py
@@ -141,13 +141,7 @@ class SampleFrames(object):
             results (dict): The resulting dict to be modified and passed
                 to the next transform in pipeline.
         """
-        if 'total_frames' not in results:
-            # TODO: find a better way to get the total frames number for video
-            video_reader = mmcv.VideoReader(results['filename'])
-            total_frames = len(video_reader)
-            results['total_frames'] = total_frames
-        else:
-            total_frames = results['total_frames']
+        total_frames = results['total_frames']
 
         clip_offsets = self._sample_clips(total_frames)
         frame_inds = clip_offsets[:, None] + np.arange(

--- a/mmaction/datasets/pipelines/loading.py
+++ b/mmaction/datasets/pipelines/loading.py
@@ -16,7 +16,7 @@ from ..registry import PIPELINES
 class SampleFrames(object):
     """Sample frames from the video.
 
-    Required keys are "filename", added or modified keys are "total_frames",
+    Required keys are "filename", "total_frames", added or modified keys are
     "frame_inds", "frame_interval" and "num_clips".
 
     Args:

--- a/tests/test_data/test_loading.py
+++ b/tests/test_data/test_loading.py
@@ -1,6 +1,7 @@
 import copy
 import os.path as osp
 
+import mmcv
 import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal, assert_array_equal
@@ -56,7 +57,9 @@ class TestLoading(object):
         cls.total_frames = 5
         cls.filename_tmpl = 'img_{:05}.jpg'
         cls.flow_filename_tmpl = '{}_{:05d}.jpg'
-        cls.video_results = dict(filename=cls.video_path, label=1)
+        video_total_frames = len(mmcv.VideoReader(cls.video_path))
+        cls.video_results = dict(
+            filename=cls.video_path, label=1, total_frames=video_total_frames)
         cls.frame_results = dict(
             frame_dir=cls.img_dir,
             total_frames=cls.total_frames,


### PR DESCRIPTION
This pr uses `xxInit()` method to get total_frames, it is a better way to get the total frames number for video.