### PR TITLE
Fix bug in work_dir.

### DIFF
--- a/tools/slurm_train.sh
+++ b/tools/slurm_train.sh
@@ -5,12 +5,11 @@ set -x
 PARTITION=$1
 JOB_NAME=$2
 CONFIG=$3
-WORK_DIR=$4
 GPUS=${GPUS:-8}
 GPUS_PER_NODE=${GPUS_PER_NODE:-8}
 CPUS_PER_TASK=${CPUS_PER_TASK:-5}
 SRUN_ARGS=${SRUN_ARGS:-""}
-PY_ARGS=${@:5}
+PY_ARGS=${@:4}
 
 PYTHONPATH="$(dirname $0)/..":$PYTHONPATH \
 srun -p ${PARTITION} \
@@ -21,4 +20,4 @@ srun -p ${PARTITION} \
     --cpus-per-task=${CPUS_PER_TASK} \
     --kill-on-bad-exit=1 \
     ${SRUN_ARGS} \
-    python -u tools/train.py ${CONFIG} --work-dir=${WORK_DIR} --launcher="slurm" ${PY_ARGS}
+    python -u tools/train.py ${CONFIG} --launcher="slurm" ${PY_ARGS}

--- a/tools/train.py
+++ b/tools/train.py
@@ -66,7 +66,7 @@ def main():
 
     # work_dir is determined in this priority:
     # CLI > config file > default (base filename)
-    if args.work_dir != '':
+    if args.work_dir is not None:
         # update configs according to CLI args if args.work_dir is not None
         cfg.work_dir = args.work_dir
     elif cfg.get('work_dir', None) is None:

--- a/tools/train.py
+++ b/tools/train.py
@@ -66,7 +66,7 @@ def main():
 
     # work_dir is determined in this priority:
     # CLI > config file > default (base filename)
-    if args.work_dir is not None:
+    if args.work_dir != '':
         # update configs according to CLI args if args.work_dir is not None
         cfg.work_dir = args.work_dir
     elif cfg.get('work_dir', None) is None:


### PR DESCRIPTION
The `args.work_dir` will never be None, it will only be `''` an empty str. When training without specific work_dir, it results in lots of logs and ckpts saved in $MMACTION2_HOME.