### PR TITLE
make pip command example more concrete

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -98,7 +98,7 @@ you can install it before installing MMCV.
 5. Some dependencies are optional. Running `python setup.py develop` will only install the minimum runtime requirements.
 To use optional dependencies like `decord`, either install them with `pip install -r requirements/optional.txt`
 or specify desired extras when calling `pip` (e.g. `pip install -v -e .[optional]`,
-valid keys for the `[optional]` field are `all`, `tests`, `build`, and `optional`) like `pip install -v -e. optional`.
+valid keys for the `[optional]` field are `all`, `tests`, `build`, and `optional`) like `pip install -v -e .[tests,build]`.
 
 ### Install with CPU only
 The code can be built for CPU only environment (where CUDA isn't available).


### PR DESCRIPTION
When I was reading the install.md , I was confused by the unclear command example. So I changed it to a more concrete example.
This is my first pull request, so I apologize if there are any mistakes.
best.