### PR TITLE
Initialize changelog.md for v0.5.0 and v0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ The master branch works with **PyTorch 1.3+**.
 
 This project is released under the [Apache 2.0 license](LICENSE).
 
+## Changelog
+
+v0.6.0 was released in 2/9/2020. Please refer to [changelog.md](docs/changelog.md) for details and release history.
+
 ## Benchmark
 | Model  |input| io backend | batch size x gpus | MMAction2 (s/iter) | MMAction (s/iter) | Temporal-Shift-Module (s/iter) | PySlowFast (s/iter) |
 | :--- | :---------------:|:---------------:| :---------------:| :---------------:  | :--------------------: | :----------------------------: | :-----------------: |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,48 @@
+## Changelog
+
+### v0.6.0 (20/8/2020)
+
+**Highlights**
+- Support NonLocal module in TSM and I3D ([#41](https://github.com/open-mmlab/mmaction2/pull/41))
+- Support SSN ([#33](https://github.com/open-mmlab/mmaction2/pull/33), [#52](https://github.com/open-mmlab/mmaction2/pull/52))
+- Support CSN model ([#87](https://github.com/open-mmlab/mmaction2/pull/87))
+- Support hmdb51 dataset preparation ([#60](https://github.com/open-mmlab/mmaction2/pull/60))
+- Enhance demo by supporting rawframe inference ([#59](https://github.com/open-mmlab/mmaction2/pull/59)),
+  output video/gif ([#72](https://github.com/open-mmlab/mmaction2/pull/72)),
+- Support encode videos from frames ([#84](https://github.com/open-mmlab/mmaction2/pull/84))
+
+**Bug Fixes**
+- `CosineAnnealing` Typo ([#47](https://github.com/open-mmlab/mmaction2/pull/47))
+- Bug fix in analyze_log ([#54](https://github.com/open-mmlab/mmaction2/pull/54))
+- Fix configs for localization test ([#67](https://github.com/open-mmlab/mmaction2/pull/67))
+- Fix the bug of generating HMDB51 class index file ([#69](https://github.com/open-mmlab/mmaction2/pull/69))
+- Fix the bug of using `loac_checkpoint()` in ResNet ([#93](https://github.com/open-mmlab/mmaction2/pull/93))
+- Fix the bug of `--work-dir` when using slurm training script ([#110](https://github.com/open-mmlab/mmaction2/pull/110))
+- Correct the sthv1/sthv2 rawframes filelist generate command ([#71](https://github.com/open-mmlab/mmaction2/pull/71))
+
+**New Features**
+- Support `with_offset` for rawframe dataset ([#48](https://github.com/open-mmlab/mmaction2/pull/48))
+- Update Slowfast modelzoo ([#51](https://github.com/open-mmlab/mmaction2/pull/51))
+- Update TSN, TSM video checkpoints ([#50](https://github.com/open-mmlab/mmaction2/pull/50))
+- Add data benchmark for TSN ([#57](https://github.com/open-mmlab/mmaction2/pull/57))
+- Add slowonly data benchmark ([#77](https://github.com/open-mmlab/mmaction2/pull/77))
+- Add BSN/BMN performance results with feature extracted by our codebase ([#99](https://github.com/open-mmlab/mmaction2/pull/99))
+
+**Improvements**
+- Polish data preparation codes ([#70](https://github.com/open-mmlab/mmaction2/pull/70))
+- Improve data preparation scripts ([#58](https://github.com/open-mmlab/mmaction2/pull/58))
+- Improve unittest coverage and minor fix ([#62](https://github.com/open-mmlab/mmaction2/pull/62))
+- Support `multi-class` in TSMHead ([#104](https://github.com/open-mmlab/mmaction2/pull/104))
+- Use `xxInit()` method to get `total_frames` and make `total_frames` a required key ([#90](https://github.com/open-mmlab/mmaction2/pull/90))
+
+### v0.5.0 (9/7/2020)
+
+**Highlights**
+- MMAction2 is released
+
+**New Features**
+- Support various datasets: UCF101, Kinetics-400, Something-Something V1&V2, Moments in Time,
+  Multi-Moments in Time, THUMOS14
+- Support various action recognition methods: TSN, TSM, R(2+1)D, I3D, SlowOnly, SlowFast, Non-local
+- Support various action localization methods: BSN, BMN
+- Colab demo for action recognition

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,9 +14,9 @@
 - Support HMDB51 dataset preparation ([#60](https://github.com/open-mmlab/mmaction2/pull/60))
 - Support encoding videos from frames ([#84](https://github.com/open-mmlab/mmaction2/pull/84))
 - Support FP16 training ([#25](https://github.com/open-mmlab/mmaction2/pull/25))
-- Support PyTorch 1.6 ([#117](https://github.com/open-mmlab/mmaction2/pull/117))
-- Support `with_offset` for rawframe dataset ([#48](https://github.com/open-mmlab/mmaction2/pull/48))
 - Enhance demo by supporting rawframe inference ([#59](https://github.com/open-mmlab/mmaction2/pull/59)), output video/gif ([#72](https://github.com/open-mmlab/mmaction2/pull/72))
+
+**ModelZoo**
 - Update Slowfast modelzoo ([#51](https://github.com/open-mmlab/mmaction2/pull/51))
 - Update TSN, TSM video checkpoints ([#50](https://github.com/open-mmlab/mmaction2/pull/50))
 - Add data benchmark for TSN ([#57](https://github.com/open-mmlab/mmaction2/pull/57))
@@ -27,6 +27,8 @@
 - Polish data preparation codes ([#70](https://github.com/open-mmlab/mmaction2/pull/70))
 - Improve data preparation scripts ([#58](https://github.com/open-mmlab/mmaction2/pull/58))
 - Improve unittest coverage and minor fix ([#62](https://github.com/open-mmlab/mmaction2/pull/62))
+- Support PyTorch 1.6 in CI ([#117](https://github.com/open-mmlab/mmaction2/pull/117))
+- Support `with_offset` for rawframe dataset ([#48](https://github.com/open-mmlab/mmaction2/pull/48))
 - Support json annotation files ([#119](https://github.com/open-mmlab/mmaction2/pull/119))
 - Support `multi-class` in TSMHead ([#104](https://github.com/open-mmlab/mmaction2/pull/104))
 - Support using `val_step()` to validate data for each `val` workflow ([#123](https://github.com/open-mmlab/mmaction2/pull/123))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@
 
 **Highlights**
 - Support NonLocal module in TSM and I3D ([#41](https://github.com/open-mmlab/mmaction2/pull/41))
-- Support SSN ([#33](https://github.com/open-mmlab/mmaction2/pull/33), [#52](https://github.com/open-mmlab/mmaction2/pull/52))
+- Support SSN ([#33](https://github.com/open-mmlab/mmaction2/pull/33), [#37](https://github.com/open-mmlab/mmaction2/pull/37), [#52](https://github.com/open-mmlab/mmaction2/pull/52), [#55](https://github.com/open-mmlab/mmaction2/pull/55))
 - Support CSN model ([#87](https://github.com/open-mmlab/mmaction2/pull/87))
 - Support hmdb51 dataset preparation ([#60](https://github.com/open-mmlab/mmaction2/pull/60))
 - Enhance demo by supporting rawframe inference ([#59](https://github.com/open-mmlab/mmaction2/pull/59)),
@@ -35,10 +35,13 @@
 - Polish data preparation codes ([#70](https://github.com/open-mmlab/mmaction2/pull/70))
 - Improve data preparation scripts ([#58](https://github.com/open-mmlab/mmaction2/pull/58))
 - Improve unittest coverage and minor fix ([#62](https://github.com/open-mmlab/mmaction2/pull/62))
+- Support json annotation files ([#119](https://github.com/open-mmlab/mmaction2/pull/119))
 - Support `multi-class` in TSMHead ([#104](https://github.com/open-mmlab/mmaction2/pull/104))
 - Support using `val_step()` to validate data for each `val` workflow ([#123](https://github.com/open-mmlab/mmaction2/pull/123))
 - Use `xxInit()` method to get `total_frames` and make `total_frames` a required key ([#90](https://github.com/open-mmlab/mmaction2/pull/90))
 - Add paper introduction in model readme ([#140](https://github.com/open-mmlab/mmaction2/pull/140))
+- Adjust the directory structure of `tools/` and rename some scripts files ([#142](https://github.com/open-mmlab/mmaction2/pull/142))
+
 
 ### v0.5.0 (9/7/2020)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-### v0.6.0 (20/8/2020)
+### v0.6.0 (30/8/2020)
 
 **Highlights**
 - Support NonLocal module in TSM and I3D ([#41](https://github.com/open-mmlab/mmaction2/pull/41))
@@ -15,17 +15,19 @@
 - `CosineAnnealing` Typo ([#47](https://github.com/open-mmlab/mmaction2/pull/47))
 - Bug fix in analyze_log ([#54](https://github.com/open-mmlab/mmaction2/pull/54))
 - Fix configs for localization test ([#67](https://github.com/open-mmlab/mmaction2/pull/67))
+- Fix configs of SlowOnly by fixing lr to 8 gpus ([#136](https://github.com/open-mmlab/mmaction2/pull/136))
 - Fix the bug of generating HMDB51 class index file ([#69](https://github.com/open-mmlab/mmaction2/pull/69))
 - Fix the bug of using `loac_checkpoint()` in ResNet ([#93](https://github.com/open-mmlab/mmaction2/pull/93))
 - Fix the bug of `--work-dir` when using slurm training script ([#110](https://github.com/open-mmlab/mmaction2/pull/110))
 - Correct the sthv1/sthv2 rawframes filelist generate command ([#71](https://github.com/open-mmlab/mmaction2/pull/71))
 
 **New Features**
+- Support PyTorch 1.6 ([#117](https://github.com/open-mmlab/mmaction2/pull/117))
 - Support `with_offset` for rawframe dataset ([#48](https://github.com/open-mmlab/mmaction2/pull/48))
 - Update Slowfast modelzoo ([#51](https://github.com/open-mmlab/mmaction2/pull/51))
 - Update TSN, TSM video checkpoints ([#50](https://github.com/open-mmlab/mmaction2/pull/50))
 - Add data benchmark for TSN ([#57](https://github.com/open-mmlab/mmaction2/pull/57))
-- Add slowonly data benchmark ([#77](https://github.com/open-mmlab/mmaction2/pull/77))
+- Add data benchmark for SlowOnly ([#77](https://github.com/open-mmlab/mmaction2/pull/77))
 - Add BSN/BMN performance results with feature extracted by our codebase ([#99](https://github.com/open-mmlab/mmaction2/pull/99))
 
 **Improvements**
@@ -33,7 +35,9 @@
 - Improve data preparation scripts ([#58](https://github.com/open-mmlab/mmaction2/pull/58))
 - Improve unittest coverage and minor fix ([#62](https://github.com/open-mmlab/mmaction2/pull/62))
 - Support `multi-class` in TSMHead ([#104](https://github.com/open-mmlab/mmaction2/pull/104))
+- Support using `val_step()` to validate data for each `val` workflow ([#123](https://github.com/open-mmlab/mmaction2/pull/123))
 - Use `xxInit()` method to get `total_frames` and make `total_frames` a required key ([#90](https://github.com/open-mmlab/mmaction2/pull/90))
+- Add paper introduction in model readme ([#140](https://github.com/open-mmlab/mmaction2/pull/140))
 
 ### v0.5.0 (9/7/2020)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,16 +1,13 @@
 ## Changelog
 
-### v0.6.0 (30/8/2020)
+### v0.6.0 (2/9/2020)
 
 **Highlights**
-- Support NonLocal module in TSM and I3D ([#41](https://github.com/open-mmlab/mmaction2/pull/41))
-- Support SSN ([#33](https://github.com/open-mmlab/mmaction2/pull/33), [#37](https://github.com/open-mmlab/mmaction2/pull/37), [#52](https://github.com/open-mmlab/mmaction2/pull/52), [#55](https://github.com/open-mmlab/mmaction2/pull/55))
-- Support CSN model ([#87](https://github.com/open-mmlab/mmaction2/pull/87))
-- Support hmdb51 dataset preparation ([#60](https://github.com/open-mmlab/mmaction2/pull/60))
-- Enhance demo by supporting rawframe inference ([#59](https://github.com/open-mmlab/mmaction2/pull/59)),
-  output video/gif ([#72](https://github.com/open-mmlab/mmaction2/pull/72)),
-- Support encode videos from frames ([#84](https://github.com/open-mmlab/mmaction2/pull/84))
-- Support FP16 training ([#25](https://github.com/open-mmlab/mmaction2/pull/25))
+- Support more action recognition methods: TIN, CSN
+- Support more action localization methods: SSN
+- Support NonLocal method
+- Support FP16 training
+- Support hmdb51 dataset
 
 **Bug Fixes**
 - `CosineAnnealing` Typo ([#47](https://github.com/open-mmlab/mmaction2/pull/47))
@@ -23,8 +20,16 @@
 - Correct the sthv1/sthv2 rawframes filelist generate command ([#71](https://github.com/open-mmlab/mmaction2/pull/71))
 
 **New Features**
+- Support NonLocal module and provide ckpt in TSM and I3D ([#41](https://github.com/open-mmlab/mmaction2/pull/41))
+- Support SSN ([#33](https://github.com/open-mmlab/mmaction2/pull/33), [#37](https://github.com/open-mmlab/mmaction2/pull/37), [#52](https://github.com/open-mmlab/mmaction2/pull/52), [#55](https://github.com/open-mmlab/mmaction2/pull/55))
+- Support CSN ([#87](https://github.com/open-mmlab/mmaction2/pull/87))
+- Support TIN ([#53](https://github.com/open-mmlab/mmaction2/pull/53))
+- Support hmdb51 dataset preparation ([#60](https://github.com/open-mmlab/mmaction2/pull/60))
+- Support encode videos from frames ([#84](https://github.com/open-mmlab/mmaction2/pull/84))
+- Support FP16 training ([#25](https://github.com/open-mmlab/mmaction2/pull/25))
 - Support PyTorch 1.6 ([#117](https://github.com/open-mmlab/mmaction2/pull/117))
 - Support `with_offset` for rawframe dataset ([#48](https://github.com/open-mmlab/mmaction2/pull/48))
+- Enhance demo by supporting rawframe inference ([#59](https://github.com/open-mmlab/mmaction2/pull/59)), output video/gif ([#72](https://github.com/open-mmlab/mmaction2/pull/72))
 - Update Slowfast modelzoo ([#51](https://github.com/open-mmlab/mmaction2/pull/51))
 - Update TSN, TSM video checkpoints ([#50](https://github.com/open-mmlab/mmaction2/pull/50))
 - Add data benchmark for TSN ([#57](https://github.com/open-mmlab/mmaction2/pull/57))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@
 - Enhance demo by supporting rawframe inference ([#59](https://github.com/open-mmlab/mmaction2/pull/59)),
   output video/gif ([#72](https://github.com/open-mmlab/mmaction2/pull/72)),
 - Support encode videos from frames ([#84](https://github.com/open-mmlab/mmaction2/pull/84))
+- Support FP16 training ([#25](https://github.com/open-mmlab/mmaction2/pull/25))
 
 **Bug Fixes**
 - `CosineAnnealing` Typo ([#47](https://github.com/open-mmlab/mmaction2/pull/47))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,29 +3,16 @@
 ### v0.6.0 (2/9/2020)
 
 **Highlights**
-- Support more action recognition methods: TIN, CSN
-- Support more action localization methods: SSN
-- Support NonLocal method
+- Support TIN, CSN, SSN, NonLocal
 - Support FP16 training
-- Support hmdb51 dataset
-
-**Bug Fixes**
-- `CosineAnnealing` Typo ([#47](https://github.com/open-mmlab/mmaction2/pull/47))
-- Bug fix in analyze_log ([#54](https://github.com/open-mmlab/mmaction2/pull/54))
-- Fix configs for localization test ([#67](https://github.com/open-mmlab/mmaction2/pull/67))
-- Fix configs of SlowOnly by fixing lr to 8 gpus ([#136](https://github.com/open-mmlab/mmaction2/pull/136))
-- Fix the bug of generating HMDB51 class index file ([#69](https://github.com/open-mmlab/mmaction2/pull/69))
-- Fix the bug of using `loac_checkpoint()` in ResNet ([#93](https://github.com/open-mmlab/mmaction2/pull/93))
-- Fix the bug of `--work-dir` when using slurm training script ([#110](https://github.com/open-mmlab/mmaction2/pull/110))
-- Correct the sthv1/sthv2 rawframes filelist generate command ([#71](https://github.com/open-mmlab/mmaction2/pull/71))
 
 **New Features**
 - Support NonLocal module and provide ckpt in TSM and I3D ([#41](https://github.com/open-mmlab/mmaction2/pull/41))
 - Support SSN ([#33](https://github.com/open-mmlab/mmaction2/pull/33), [#37](https://github.com/open-mmlab/mmaction2/pull/37), [#52](https://github.com/open-mmlab/mmaction2/pull/52), [#55](https://github.com/open-mmlab/mmaction2/pull/55))
 - Support CSN ([#87](https://github.com/open-mmlab/mmaction2/pull/87))
 - Support TIN ([#53](https://github.com/open-mmlab/mmaction2/pull/53))
-- Support hmdb51 dataset preparation ([#60](https://github.com/open-mmlab/mmaction2/pull/60))
-- Support encode videos from frames ([#84](https://github.com/open-mmlab/mmaction2/pull/84))
+- Support HMDB51 dataset preparation ([#60](https://github.com/open-mmlab/mmaction2/pull/60))
+- Support encoding videos from frames ([#84](https://github.com/open-mmlab/mmaction2/pull/84))
 - Support FP16 training ([#25](https://github.com/open-mmlab/mmaction2/pull/25))
 - Support PyTorch 1.6 ([#117](https://github.com/open-mmlab/mmaction2/pull/117))
 - Support `with_offset` for rawframe dataset ([#48](https://github.com/open-mmlab/mmaction2/pull/48))
@@ -46,6 +33,16 @@
 - Use `xxInit()` method to get `total_frames` and make `total_frames` a required key ([#90](https://github.com/open-mmlab/mmaction2/pull/90))
 - Add paper introduction in model readme ([#140](https://github.com/open-mmlab/mmaction2/pull/140))
 - Adjust the directory structure of `tools/` and rename some scripts files ([#142](https://github.com/open-mmlab/mmaction2/pull/142))
+
+**Bug Fixes**
+- Fix configs for localization test ([#67](https://github.com/open-mmlab/mmaction2/pull/67))
+- Fix configs of SlowOnly by fixing lr to 8 gpus ([#136](https://github.com/open-mmlab/mmaction2/pull/136))
+- Fix the bug in analyze_log ([#54](https://github.com/open-mmlab/mmaction2/pull/54))
+- Fix the bug of generating HMDB51 class index file ([#69](https://github.com/open-mmlab/mmaction2/pull/69))
+- Fix the bug of using `load_checkpoint()` in ResNet ([#93](https://github.com/open-mmlab/mmaction2/pull/93))
+- Fix the bug of `--work-dir` when using slurm training script ([#110](https://github.com/open-mmlab/mmaction2/pull/110))
+- Correct the sthv1/sthv2 rawframes filelist generate command ([#71](https://github.com/open-mmlab/mmaction2/pull/71))
+- `CosineAnnealing` typo ([#47](https://github.com/open-mmlab/mmaction2/pull/47))
 
 
 ### v0.5.0 (9/7/2020)


### PR DESCRIPTION
This PR initializes changelog.md docs for v0.5.0 and v0.6.0. Any import changes should be categorized (I suggest using [tag] in each PR for convenience) and logged in this this PR. @kennymckormick @SuX97 @innerlee @JoannaLXY @tony2016uestc 