### PR TITLE
Support Json annotations

### DIFF
--- a/mmaction/datasets/base.py
+++ b/mmaction/datasets/base.py
@@ -4,7 +4,6 @@ from abc import ABCMeta, abstractmethod
 
 import mmcv
 import torch
-from mmcv import load
 from torch.utils.data import Dataset
 
 from .pipelines import Compose
@@ -73,7 +72,7 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
     # this func should be the same
     def load_json_annotations(self):
         """Load json annotation file to get video information."""
-        video_infos = load(self.ann_file)
+        video_infos = mmcv.load(self.ann_file)
         num_videos = len(video_infos)
         path_key = 'frame_dir' if 'frame_dir' in video_infos[0] else 'filename'
         for i in range(num_videos):

--- a/mmaction/datasets/base.py
+++ b/mmaction/datasets/base.py
@@ -75,11 +75,12 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
         """Load json annotation file to get video information."""
         video_infos = load(self.ann_file)
         num_videos = len(video_infos)
+        path_key = 'frame_dir' if 'frame_dir' in video_infos[0] else 'filename'
         for i in range(num_videos):
             if self.data_prefix is not None:
-                frame_dir = video_infos[i]['frame_dir']
-                frame_dir = osp.join(self.data_prefix, frame_dir)
-                video_infos[i]['frame_dir'] = frame_dir
+                path_value = video_infos[i][path_key]
+                path_value = osp.join(self.data_prefix, path_value)
+                video_infos[i][path_key] = path_value
             if self.multi_class:
                 assert self.num_classes is not None
                 onehot = torch.zeros(self.num_classes)

--- a/mmaction/datasets/rawframe_dataset.py
+++ b/mmaction/datasets/rawframe_dataset.py
@@ -148,6 +148,7 @@ class RawframeDataset(BaseDataset):
             for i in range(num_videos):
                 assert len(video_infos[i]['label']) == 1
                 video_infos[i]['label'] = video_infos[i]['label'][0]
+        return video_infos
 
     def prepare_train_frames(self, idx):
         """Prepare the frames for training given the index."""

--- a/mmaction/datasets/rawframe_dataset.py
+++ b/mmaction/datasets/rawframe_dataset.py
@@ -2,7 +2,6 @@ import copy
 import os.path as osp
 
 import torch
-from mmcv import load
 from mmcv.utils import print_log
 
 from ..core import mean_average_precision, mean_class_accuracy, top_k_accuracy
@@ -131,23 +130,6 @@ class RawframeDataset(BaseDataset):
                     video_info['label'] = label[0]
                 video_infos.append(video_info)
 
-        return video_infos
-
-    def load_json_annotations(self):
-        """Load json annotation file to get video information."""
-        video_infos = load(self.ann_file)
-        num_videos = len(video_infos)
-        # only need to process label here
-        if self.multi_class:
-            assert self.num_classes is not None
-            for i in range(num_videos):
-                onehot = torch.zeros(self.num_classes)
-                onehot[video_infos[i]['label']] = 1.0
-                video_infos[i]['label'] = onehot
-        else:
-            for i in range(num_videos):
-                assert len(video_infos[i]['label']) == 1
-                video_infos[i]['label'] = video_infos[i]['label'][0]
         return video_infos
 
     def prepare_train_frames(self, idx):

--- a/mmaction/datasets/video_dataset.py
+++ b/mmaction/datasets/video_dataset.py
@@ -84,6 +84,7 @@ class VideoDataset(BaseDataset):
             for i in range(num_videos):
                 assert len(video_infos[i]['label']) == 1
                 video_infos[i]['label'] = video_infos[i]['label'][0]
+        return video_infos
 
     def evaluate(self,
                  results,

--- a/mmaction/datasets/video_dataset.py
+++ b/mmaction/datasets/video_dataset.py
@@ -1,7 +1,6 @@
 import os.path as osp
 
 import torch
-from mmcv import load
 from mmcv.utils import print_log
 
 from ..core import mean_class_accuracy, top_k_accuracy
@@ -67,23 +66,6 @@ class VideoDataset(BaseDataset):
                     dict(
                         filename=filename,
                         label=onehot if self.multi_class else label))
-        return video_infos
-
-    def load_json_annotations(self):
-        """Load json annotation file to get video information."""
-        video_infos = load(self.ann_file)
-        num_videos = len(video_infos)
-        # only need to process label here
-        if self.multi_class:
-            assert self.num_classes is not None
-            for i in range(num_videos):
-                onehot = torch.zeros(self.num_classes)
-                onehot[video_infos[i]['label']] = 1.0
-                video_infos[i]['label'] = onehot
-        else:
-            for i in range(num_videos):
-                assert len(video_infos[i]['label']) == 1
-                video_infos[i]['label'] = video_infos[i]['label'][0]
         return video_infos
 
     def evaluate(self,

--- a/mmaction/datasets/video_dataset.py
+++ b/mmaction/datasets/video_dataset.py
@@ -1,6 +1,7 @@
 import os.path as osp
 
 import torch
+from mmcv import load
 from mmcv.utils import print_log
 
 from ..core import mean_class_accuracy, top_k_accuracy
@@ -44,6 +45,9 @@ class VideoDataset(BaseDataset):
 
     def load_annotations(self):
         """Load annotation file to get video information."""
+        if self.ann_file.endswith('.json'):
+            return self.load_json_annotations()
+
         video_infos = []
         with open(self.ann_file, 'r') as fin:
             for line in fin:
@@ -64,6 +68,22 @@ class VideoDataset(BaseDataset):
                         filename=filename,
                         label=onehot if self.multi_class else label))
         return video_infos
+
+    def load_json_annotations(self):
+        """Load json annotation file to get video information."""
+        video_infos = load(self.ann_file)
+        num_videos = len(video_infos)
+        # only need to process label here
+        if self.multi_class:
+            assert self.num_classes is not None
+            for i in range(num_videos):
+                onehot = torch.zeros(self.num_classes)
+                onehot[video_infos[i]['label']] = 1.0
+                video_infos[i]['label'] = onehot
+        else:
+            for i in range(num_videos):
+                assert len(video_infos[i]['label']) == 1
+                video_infos[i]['label'] = video_infos[i]['label'][0]
 
     def evaluate(self,
                  results,

--- a/tools/data/anno_txt2json.py
+++ b/tools/data/anno_txt2json.py
@@ -71,7 +71,7 @@ def lines2dictlist(lines, format):
         format (str): Data format, choices are 'rawframes' and 'videos'.
 
     Returns:
-        list[diction]: For rawframes format, each diction has keys: frame_dir,
+        list[dict]: For rawframes format, each dict has keys: frame_dir,
             total_frames, label; for videos format, each diction has keys:
             filename, label.
     """

--- a/tools/data/anno_txt2json.py
+++ b/tools/data/anno_txt2json.py
@@ -27,8 +27,8 @@ def parse_args():
 
 
 def lines2dictlist(lines, format):
-    """Convert lines in 'txt' format to dictions in 'json' format. Currently
-    support single-label and multi-label.
+    """Convert lines in 'txt' format to dictionaries in 'json' format.
+    Currently support single-label and multi-label.
 
     Example of a single-label rawframes annotation txt file:
 

--- a/tools/data/anno_txt2json.py
+++ b/tools/data/anno_txt2json.py
@@ -1,19 +1,19 @@
 import argparse
 
-from mmcv import dump
+import mmcv
 
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description='Convert txt anno list to json')
+        description='Convert txt annotation list to json')
     parser.add_argument(
-        'annofile', type=str, help='the txt annofile to convert')
+        'annofile', type=str, help='the txt annotation file to convert')
     parser.add_argument(
         '--format',
         type=str,
         default='rawframes',
         choices=['rawframes', 'videos'],
-        help='the format of the txt annofile')
+        help='the format of the txt annotation file')
     parser.add_argument(
         '--output',
         type=str,
@@ -30,12 +30,44 @@ def lines2dictlist(lines, format):
     """Convert lines in 'txt' format to dictions in 'json' format. Currently
     support single-label and multi-label.
 
+    Example of a single-label rawframes annotation txt file:
+
+    .. code-block:: txt
+
+        (frame_dir num_frames label)
+        some/directory-1 163 1
+        some/directory-2 122 1
+        some/directory-3 258 2
+
+    Example of a multi-label rawframes annotation txt file:
+
+    .. code-block:: txt
+
+        (frame_dir num_frames label1 label2 ...)
+        some/directory-1 163 1 3 5
+        some/directory-2 122 1 2
+        some/directory-3 258 2
+
+    Example of a single-label videos annotation txt file:
+
+    .. code-block:: txt
+
+        (filename label)
+        some/path/000.mp4 1
+        some/path/001.mp4 1
+        some/path/002.mp4 2
+
+    Example of a multi-label videos annotation txt file:
+
+    .. code-block:: txt
+
+        (filename label1 label2 ...)
+        some/path/000.mp4 1 3 5
+        some/path/001.mp4 1 4 8
+        some/path/002.mp4 2 4 9
+
     Args:
         lines (list): List of lines in 'txt' label format.
-            'frame_dir num_frame label' (rawframes + single-label)
-            'frame_dir num_frame label1 label2 ...' (rawframes + multi-label)
-            'filename label' (videos + single-label)
-            'filename label1 label2 ...' (videos + multi-label)
         format (str): Data format, choices are 'rawframes' and 'videos'.
 
     Returns:
@@ -67,4 +99,4 @@ if __name__ == '__main__':
     result = lines2dictlist(lines, args.format)
     if args.output is None:
         args.output = args.annofile.replace('.txt', '.json')
-    dump(result, args.output)
+    mmcv.dump(result, args.output)

--- a/tools/data/anno_txt2json.py
+++ b/tools/data/anno_txt2json.py
@@ -1,0 +1,70 @@
+import argparse
+
+from mmcv import dump
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Convert txt anno list to json')
+    parser.add_argument(
+        'annofile', type=str, help='the txt annofile to convert')
+    parser.add_argument(
+        '--format',
+        type=str,
+        default='rawframes',
+        choices=['rawframes', 'videos'],
+        help='the format of the txt annofile')
+    parser.add_argument(
+        '--output',
+        type=str,
+        default=None,
+        help=(
+            'the output file name, use annofile.replace(\'.txt\', \'.json\') '
+            'if the arg value is None'))
+    args = parser.parse_args()
+
+    return args
+
+
+def lines2dictlist(lines, format):
+    """Convert lines in 'txt' format to dictions in 'json' format. Currently
+    support single-label and multi-label.
+
+    Args:
+        lines (list): List of lines in 'txt' label format.
+            'frame_dir num_frame label' (rawframes + single-label)
+            'frame_dir num_frame label1 label2 ...' (rawframes + multi-label)
+            'filename label' (videos + single-label)
+            'filename label1 label2 ...' (videos + multi-label)
+        format (str): Data format, choices are 'rawframes' and 'videos'.
+
+    Returns:
+        list[diction]: For rawframes format, each diction has keys: frame_dir,
+            total_frames, label; for videos format, each diction has keys:
+            filename, label.
+    """
+    lines = [x.split() for x in lines]
+    if format == 'rawframes':
+        data = [
+            dict(
+                frame_dir=line[0],
+                total_frames=int(line[1]),
+                label=[int(x) for x in line[2:]]) for line in lines
+        ]
+    elif format == 'videos':
+        data = [
+            dict(filename=line[0], label=[int(x) for x in line[1:]])
+            for line in lines
+        ]
+    return data
+
+
+if __name__ == '__main__':
+    # convert txt anno list to json
+    args = parse_args()
+    lines = open(args.annofile).readlines()
+    lines = [x.strip() for x in lines]
+    result = lines2dictlist(lines)
+    if args.output is None:
+        args.output = args.annofile.replace('.txt', '.json')
+    dump(result, args.output)

--- a/tools/data/anno_txt2json.py
+++ b/tools/data/anno_txt2json.py
@@ -64,7 +64,7 @@ if __name__ == '__main__':
     args = parse_args()
     lines = open(args.annofile).readlines()
     lines = [x.strip() for x in lines]
-    result = lines2dictlist(lines)
+    result = lines2dictlist(lines, args.format)
     if args.output is None:
         args.output = args.annofile.replace('.txt', '.json')
     dump(result, args.output)

--- a/tools/data/build_file_list.py
+++ b/tools/data/build_file_list.py
@@ -167,7 +167,9 @@ def lines2dictlist(lines, format):
         format (str): Data format, choices are 'rawframes' and 'videos'.
 
     Returns:
-        list: list of dictions
+        list[diction]: For rawframes format, each diction has keys: frame_dir,
+            total_frames, label; for videos format, each diction has keys:
+            filename, label.
     """
     lines = [x.split() for x in lines]
     if format == 'rawframes':

--- a/tools/data/build_file_list.py
+++ b/tools/data/build_file_list.py
@@ -155,16 +155,33 @@ def build_file_list(splits, frame_info, shuffle=False):
 
 
 def lines2dictlist(lines, format):
+    """Convert lines in 'txt' format to dictions in 'json' format. Currently
+    support single-label and multi-label.
+
+    Args:
+        lines (list): List of lines in 'txt' label format.
+            'frame_dir num_frame label' (rawframes + single-label)
+            'frame_dir num_frame label1 label2 ...' (rawframes + multi-label)
+            'filename label' (videos + single-label)
+            'filename label1 label2 ...' (videos + multi-label)
+        format (str): Data format, choices are 'rawframes' and 'videos'.
+
+    Returns:
+        list: list of dictions
+    """
     lines = [x.split() for x in lines]
     if format == 'rawframes':
-        assert len(lines[0]) == 3
         data = [
-            dict(frame_dir=line[0], total_frames=line[1], label=line[2])
-            for line in lines
+            dict(
+                frame_dir=line[0],
+                total_frames=int(line[1]),
+                label=[int(x) for x in line[2:]]) for line in lines
         ]
     elif format == 'videos':
-        assert len(lines[0]) == 2
-        data = [dict(filename=line[0], label=line[1]) for line in lines]
+        data = [
+            dict(filename=line[0], label=[int(x) for x in line[1:]])
+            for line in lines
+        ]
     return data
 
 

--- a/tools/data/build_file_list.py
+++ b/tools/data/build_file_list.py
@@ -4,6 +4,7 @@ import json
 import os.path as osp
 import random
 
+from tools.data.anno_txt2json import lines2dictlist
 from tools.data.parse_file_list import (parse_directory, parse_hmdb51_split,
                                         parse_kinetics_splits,
                                         parse_mit_splits, parse_mmit_splits,
@@ -152,39 +153,6 @@ def build_file_list(splits, frame_info, shuffle=False):
     train_rgb_list, train_flow_list = build_list(splits[0])
     test_rgb_list, test_flow_list = build_list(splits[1])
     return (train_rgb_list, test_rgb_list), (train_flow_list, test_flow_list)
-
-
-def lines2dictlist(lines, format):
-    """Convert lines in 'txt' format to dictions in 'json' format. Currently
-    support single-label and multi-label.
-
-    Args:
-        lines (list): List of lines in 'txt' label format.
-            'frame_dir num_frame label' (rawframes + single-label)
-            'frame_dir num_frame label1 label2 ...' (rawframes + multi-label)
-            'filename label' (videos + single-label)
-            'filename label1 label2 ...' (videos + multi-label)
-        format (str): Data format, choices are 'rawframes' and 'videos'.
-
-    Returns:
-        list[diction]: For rawframes format, each diction has keys: frame_dir,
-            total_frames, label; for videos format, each diction has keys:
-            filename, label.
-    """
-    lines = [x.split() for x in lines]
-    if format == 'rawframes':
-        data = [
-            dict(
-                frame_dir=line[0],
-                total_frames=int(line[1]),
-                label=[int(x) for x in line[2:]]) for line in lines
-        ]
-    elif format == 'videos':
-        data = [
-            dict(filename=line[0], label=[int(x) for x in line[1:]])
-            for line in lines
-        ]
-    return data
 
 
 def main():


### PR DESCRIPTION
Support the new json annotation format, which is more scalable than txt files: 

1. You can use the command `python tools/data/anno_txt2json.py annotation.txt` to convert it from txt to json.
2. The dataset can automatically detect json annotation list and load it.
3. When the repo decides to switch from txt to json, just change the default option of output_format in `build_file_list.py`  to 'json'