### PR TITLE
Bug fix in CSN mode setting

### DIFF
--- a/mmaction/models/backbones/resnet3d_csn.py
+++ b/mmaction/models/backbones/resnet3d_csn.py
@@ -137,7 +137,7 @@ class ResNet3dCSN(ResNet3d):
             **kwargs)
 
     def train(self, mode=True):
-        super(ResNet3d, self).train()
+        super(ResNet3d, self).train(mode)
         self._freeze_stages()
         if mode and self.norm_eval:
             for m in self.modules():

--- a/tests/test_models/test_backbone.py
+++ b/tests/test_models/test_backbone.py
@@ -797,6 +797,13 @@ def test_resnet_csn_backbone():
         feat = resnet3d_csn_ir(imgs)
         assert feat.shape == torch.Size([2, 2048, 1, 2, 2])
 
+    # Set training status = False
+    resnet3d_csn_ip = ResNet3dCSN(152, None, bottleneck_mode='ip')
+    resnet3d_csn_ip.init_weights()
+    resnet3d_csn_ip.train(False)
+    for module in resnet3d_csn_ip.children():
+        assert module.training is False
+
 
 def _demo_inputs(input_shape=(1, 3, 64, 64)):
     """Create a superset of inputs needed to run backbone.


### PR DESCRIPTION
This PR fixes bug, which affects the testing, in `def train(self, mode=True):` in CSN. The modification has been well tested.