### PR TITLE
Move identical `evaluate` into BaseDataset

### DIFF
--- a/mmaction/datasets/base.py
+++ b/mmaction/datasets/base.py
@@ -4,8 +4,10 @@ from abc import ABCMeta, abstractmethod
 
 import mmcv
 import torch
+from mmcv.utils import print_log
 from torch.utils.data import Dataset
 
+from ..core import mean_average_precision, mean_class_accuracy, top_k_accuracy
 from .pipelines import Compose
 
 
@@ -90,19 +92,83 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
                 video_infos[i]['label'] = video_infos[i]['label'][0]
         return video_infos
 
-    @abstractmethod
-    def evaluate(self, results, metrics, logger):
-        """Evaluation for the dataset.
+    def evaluate(self,
+                 results,
+                 metrics='top_k_accuracy',
+                 topk=(1, 5),
+                 logger=None):
+        """Evaluation in rawframe dataset.
 
         Args:
             results (list): Output results.
             metrics (str | sequence[str]): Metrics to be performed.
+                Defaults: 'top_k_accuracy'.
+            logger (obj): Training logger. Defaults: None.
+            topk (int | tuple[int]): K value for top_k_accuracy metric.
+                Defaults: (1, 5).
             logger (logging.Logger | None): Logger for recording.
+                Default: None.
 
         Returns:
             dict: Evaluation results dict.
         """
-        pass
+
+        if not isinstance(results, list):
+            raise TypeError(f'results must be a list, but got {type(results)}')
+        assert len(results) == len(self), (
+            f'The length of results is not equal to the dataset len: '
+            f'{len(results)} != {len(self)}')
+
+        if not isinstance(topk, (int, tuple)):
+            raise TypeError(
+                f'topk must be int or tuple of int, but got {type(topk)}')
+
+        if isinstance(topk, int):
+            topk = (topk, )
+
+        metrics = metrics if isinstance(metrics, (list, tuple)) else [metrics]
+        allowed_metrics = [
+            'top_k_accuracy', 'mean_class_accuracy', 'mean_average_precision'
+        ]
+        for metric in metrics:
+            if metric not in allowed_metrics:
+                raise KeyError(f'metric {metric} is not supported')
+
+        eval_results = {}
+        gt_labels = [ann['label'] for ann in self.video_infos]
+
+        for metric in metrics:
+            msg = f'Evaluating {metric}...'
+            if logger is None:
+                msg = '\n' + msg
+            print_log(msg, logger=logger)
+
+            if metric == 'top_k_accuracy':
+                top_k_acc = top_k_accuracy(results, gt_labels, topk)
+                log_msg = []
+                for k, acc in zip(topk, top_k_acc):
+                    eval_results[f'top{k}_acc'] = acc
+                    log_msg.append(f'\ntop{k}_acc\t{acc:.4f}')
+                log_msg = ''.join(log_msg)
+                print_log(log_msg, logger=logger)
+                continue
+
+            if metric == 'mean_class_accuracy':
+                mean_acc = mean_class_accuracy(results, gt_labels)
+                eval_results['mean_class_accuracy'] = mean_acc
+                log_msg = f'\nmean_acc\t{mean_acc:.4f}'
+                print_log(log_msg, logger=logger)
+                continue
+
+            if metric == 'mean_average_precision':
+                gt_labels = [label.cpu().numpy() for label in gt_labels]
+                mAP = mean_average_precision(results, gt_labels)
+                eval_results['mean_average_precision'] = mAP
+                log_msg = f'\nmean_average_precision\t{mAP:.4f}'
+                print_log(log_msg, logger=logger)
+                continue
+
+        return eval_results
 
     def dump_results(self, results, out):
         """Dump data to json/yaml/pickle strings or files."""

--- a/mmaction/datasets/rawframe_dataset.py
+++ b/mmaction/datasets/rawframe_dataset.py
@@ -2,9 +2,7 @@ import copy
 import os.path as osp
 
 import torch
-from mmcv.utils import print_log
 
-from ..core import mean_average_precision, mean_class_accuracy, top_k_accuracy
 from .base import BaseDataset
 from .registry import DATASETS
 
@@ -147,81 +145,3 @@ class RawframeDataset(BaseDataset):
         results['modality'] = self.modality
         results['start_index'] = self.start_index
         return self.pipeline(results)
-
-    def evaluate(self,
-                 results,
-                 metrics='top_k_accuracy',
-                 topk=(1, 5),
-                 logger=None):
-        """Evaluation in rawframe dataset.
-
-        Args:
-            results (list): Output results.
-            metrics (str | sequence[str]): Metrics to be performed.
-                Defaults: 'top_k_accuracy'.
-            logger (obj): Training logger. Defaults: None.
-            topk (int | tuple[int]): K value for top_k_accuracy metric.
-                Defaults: (1, 5).
-            logger (logging.Logger | None): Logger for recording.
-                Default: None.
-
-        Returns:
-            dict: Evaluation results dict.
-        """
-
-        if not isinstance(results, list):
-            raise TypeError(f'results must be a list, but got {type(results)}')
-        assert len(results) == len(self), (
-            f'The length of results is not equal to the dataset len: '
-            f'{len(results)} != {len(self)}')
-
-        if not isinstance(topk, (int, tuple)):
-            raise TypeError(
-                f'topk must be int or tuple of int, but got {type(topk)}')
-
-        if isinstance(topk, int):
-            topk = (topk, )
-
-        metrics = metrics if isinstance(metrics, (list, tuple)) else [metrics]
-        allowed_metrics = [
-            'top_k_accuracy', 'mean_class_accuracy', 'mean_average_precision'
-        ]
-        for metric in metrics:
-            if metric not in allowed_metrics:
-                raise KeyError(f'metric {metric} is not supported')
-
-        eval_results = {}
-        gt_labels = [ann['label'] for ann in self.video_infos]
-
-        for metric in metrics:
-            msg = f'Evaluating {metric}...'
-            if logger is None:
-                msg = '\n' + msg
-            print_log(msg, logger=logger)
-
-            if metric == 'top_k_accuracy':
-                top_k_acc = top_k_accuracy(results, gt_labels, topk)
-                log_msg = []
-                for k, acc in zip(topk, top_k_acc):
-                    eval_results[f'top{k}_acc'] = acc
-                    log_msg.append(f'\ntop{k}_acc\t{acc:.4f}')
-                log_msg = ''.join(log_msg)
-                print_log(log_msg, logger=logger)
-                continue
-
-            if metric == 'mean_class_accuracy':
-                mean_acc = mean_class_accuracy(results, gt_labels)
-                eval_results['mean_class_accuracy'] = mean_acc
-                log_msg = f'\nmean_acc\t{mean_acc:.4f}'
-                print_log(log_msg, logger=logger)
-                continue
-
-            if metric == 'mean_average_precision':
-                gt_labels = [label.cpu().numpy() for label in gt_labels]
-                mAP = mean_average_precision(results, gt_labels)
-                eval_results['mean_average_precision'] = mAP
-                log_msg = f'\nmean_average_precision\t{mAP:.4f}'
-                print_log(log_msg, logger=logger)
-                continue
-
-        return eval_results

--- a/mmaction/datasets/video_dataset.py
+++ b/mmaction/datasets/video_dataset.py
@@ -1,9 +1,7 @@
 import os.path as osp
 
 import torch
-from mmcv.utils import print_log
 
-from ..core import mean_class_accuracy, top_k_accuracy
 from .base import BaseDataset
 from .registry import DATASETS
 
@@ -67,67 +65,3 @@ class VideoDataset(BaseDataset):
                         filename=filename,
                         label=onehot if self.multi_class else label))
         return video_infos
-
-    def evaluate(self,
-                 results,
-                 metrics='top_k_accuracy',
-                 topk=(1, 5),
-                 logger=None):
-        """Evaluation in rawframe dataset.
-
-        Args:
-            results (list): Output results.
-            metrics (str | sequence[str]): Metrics to be performed.
-                Defaults: 'top_k_accuracy'.
-            logger (obj): Training logger. Defaults: None.
-            topk (tuple[int]): K value for top_k_accuracy metric.
-                Defaults: (1, 5).
-            logger (logging.Logger | None): Logger for recording.
-                Default: None.
-
-        Return:
-            dict: Evaluation results dict.
-        """
-        if not isinstance(results, list):
-            raise TypeError(f'results must be a list, but got {type(results)}')
-        assert len(results) == len(self), (
-            f'The length of results is not equal to the dataset len: '
-            f'{len(results)} != {len(self)}')
-
-        if not isinstance(topk, (int, tuple)):
-            raise TypeError(
-                f'topk must be int or tuple of int, but got {type(topk)}')
-
-        metrics = metrics if isinstance(metrics, (list, tuple)) else [metrics]
-        allowed_metrics = ['top_k_accuracy', 'mean_class_accuracy']
-        for metric in metrics:
-            if metric not in allowed_metrics:
-                raise KeyError(f'metric {metric} is not supported')
-
-        eval_results = {}
-        gt_labels = [ann['label'] for ann in self.video_infos]
-
-        for metric in metrics:
-            msg = f'Evaluating {metric}...'
-            if logger is None:
-                msg = '\n' + msg
-            print_log(msg, logger=logger)
-
-            if metric == 'top_k_accuracy':
-                top_k_acc = top_k_accuracy(results, gt_labels, topk)
-                log_msg = []
-                for k, acc in zip(topk, top_k_acc):
-                    eval_results[f'top{k}_acc'] = acc
-                    log_msg.append(f'\ntop{k}_acc\t{acc:.4f}')
-                log_msg = ''.join(log_msg)
-                print_log(log_msg, logger=logger)
-                continue
-
-            if metric == 'mean_class_accuracy':
-                mean_acc = mean_class_accuracy(results, gt_labels)
-                eval_results['mean_class_accuracy'] = mean_acc
-                log_msg = f'\nmean_acc\t{mean_acc:.4f}'
-                print_log(log_msg, logger=logger)
-                continue
-
-        return eval_results


### PR DESCRIPTION
These two are pretty much the same, and will not differ even when the user writes a new dataset. When the user writes a new evaluation metric, he/she only needs to modify it in BaseDataset.