### PR TITLE
Add try-except in tin_shift importing

### DIFF
--- a/mmaction/models/backbones/resnet_tin.py
+++ b/mmaction/models/backbones/resnet_tin.py
@@ -1,9 +1,15 @@
+import warnings
+
 import torch
 import torch.nn as nn
-from mmcv.ops import tin_shift
 
 from ..registry import BACKBONES
 from .resnet_tsm import ResNetTSM
+
+try:
+    from mmcv.ops import tin_shift
+except ImportError:
+    warnings.warn('Please install mmcv-full to support "tin_shift"')
 
 
 def linear_sampler(data, offset):


### PR DESCRIPTION
This PR adds `try-except` in `tin_shift` importing for users who do not need `TIN`.