### PR TITLE
Change default value of `norm_eval` to False

### DIFF
--- a/mmaction/models/backbones/resnet.py
+++ b/mmaction/models/backbones/resnet.py
@@ -315,7 +315,7 @@ class ResNet(nn.Module):
         act_cfg (dict): Config for activate layers.
             Default: dict(type='ReLU', inplace=True).
         norm_eval (bool): Whether to set BN layers to eval mode, namely, freeze
-            running stats (mean and var). Default: True.
+            running stats (mean and var). Default: False.
         partial_bn (bool): Whether to use partial bn. Default: False.
         with_cp (bool): Use checkpoint or not. Using checkpoint will save some
             memory while slowing down the training speed. Default: False.
@@ -342,7 +342,7 @@ class ResNet(nn.Module):
                  conv_cfg=dict(type='Conv'),
                  norm_cfg=dict(type='BN2d', requires_grad=True),
                  act_cfg=dict(type='ReLU', inplace=True),
-                 norm_eval=True,
+                 norm_eval=False,
                  partial_bn=False,
                  with_cp=False):
         super().__init__()

--- a/mmaction/models/backbones/resnet.py
+++ b/mmaction/models/backbones/resnet.py
@@ -557,10 +557,11 @@ class ResNet(nn.Module):
     def _partial_bn(self):
         logger = get_root_logger()
         logger.info('Freezing BatchNorm2D except the first one.')
-        for layer_name in self.res_layers:
-            res_layer = getattr(self, layer_name)
-            for m in res_layer.modules():
-                if isinstance(m, nn.BatchNorm2d):
+        count_bn = 0
+        for m in self.modules():
+            if isinstance(m, nn.BatchNorm2d):
+                count_bn += 1
+                if count_bn >= 2:
                     m.eval()
                     # shutdown update in frozen mode
                     m.weight.requires_grad = False

--- a/mmaction/models/backbones/resnet.py
+++ b/mmaction/models/backbones/resnet.py
@@ -557,11 +557,10 @@ class ResNet(nn.Module):
     def _partial_bn(self):
         logger = get_root_logger()
         logger.info('Freezing BatchNorm2D except the first one.')
-        count_bn = 0
-        for m in self.modules():
-            if isinstance(m, nn.BatchNorm2d):
-                count_bn += 1
-                if count_bn >= 2:
+        for layer_name in self.res_layers:
+            res_layer = getattr(self, layer_name)
+            for m in res_layer.modules():
+                if isinstance(m, nn.BatchNorm2d):
                     m.eval()
                     # shutdown update in frozen mode
                     m.weight.requires_grad = False

--- a/mmaction/models/backbones/resnet3d.py
+++ b/mmaction/models/backbones/resnet3d.py
@@ -362,7 +362,7 @@ class ResNet3d(nn.Module):
         act_cfg (dict): Config dict for activation layer.
             Default: ``dict(type='ReLU', inplace=True)``.
         norm_eval (bool): Whether to set BN layers to eval mode, namely, freeze
-            running stats (mean and var). Default: True.
+            running stats (mean and var). Default: False.
         with_cp (bool): Use checkpoint or not. Using checkpoint will save some
             memory while slowing down the training speed. Default: False.
         non_local (Sequence[int]): Determine whether to apply non-local module
@@ -403,7 +403,7 @@ class ResNet3d(nn.Module):
                  conv_cfg=dict(type='Conv3d'),
                  norm_cfg=dict(type='BN3d', requires_grad=True),
                  act_cfg=dict(type='ReLU', inplace=True),
-                 norm_eval=True,
+                 norm_eval=False,
                  with_cp=False,
                  non_local=(0, 0, 0, 0),
                  non_local_cfg=dict(),

--- a/tests/test_models/test_backbone.py
+++ b/tests/test_models/test_backbone.py
@@ -89,14 +89,18 @@ def test_resnet_backbone():
     # resnet with depth 50, partial batchnorm
     resnet_pbn = ResNet(50, partial_bn=True)
     resnet_pbn.train()
-    assert resnet_pbn.conv1.bn.weight.requires_grad is True
-    assert resnet_pbn.conv1.bn.bias.requires_grad is True
-    for layer_name in resnet_pbn.res_layers:
-        res_layer = getattr(resnet_pbn, layer_name)
-        for m in res_layer.modules():
-            if isinstance(m, nn.BatchNorm2d):
+    count_bn = 0
+    for m in resnet_pbn.modules():
+        if isinstance(m, nn.BatchNorm2d):
+            count_bn += 1
+            if count_bn >= 2:
                 assert m.weight.requires_grad is False
                 assert m.bias.requires_grad is False
+                assert m.training is False
+            else:
+                assert m.weight.requires_grad is True
+                assert m.bias.requires_grad is True
+                assert m.training is True
 
     input_shape = (1, 3, 64, 64)
     imgs = _demo_inputs(input_shape)

--- a/tests/test_models/test_backbone.py
+++ b/tests/test_models/test_backbone.py
@@ -87,19 +87,16 @@ def test_resnet_backbone():
             assert param.requires_grad is False
 
     # resnet with depth 50, partial batchnorm
-    resnet_pbn = ResNet(50, norm_eval=True, partial_bn=True)
+    resnet_pbn = ResNet(50, partial_bn=True)
     resnet_pbn.train()
-    count_bn = 0
-    for m in resnet_pbn.modules():
-        if isinstance(m, nn.BatchNorm2d):
-            assert m.training is False
-            count_bn += 1
-            if count_bn >= 2:
+    assert resnet_pbn.conv1.bn.weight.requires_grad is True
+    assert resnet_pbn.conv1.bn.bias.requires_grad is True
+    for layer_name in resnet_pbn.res_layers:
+        res_layer = getattr(resnet_pbn, layer_name)
+        for m in res_layer.modules():
+            if isinstance(m, nn.BatchNorm2d):
                 assert m.weight.requires_grad is False
                 assert m.bias.requires_grad is False
-            else:
-                assert m.weight.requires_grad is True
-                assert m.bias.requires_grad is True
 
     input_shape = (1, 3, 64, 64)
     imgs = _demo_inputs(input_shape)

--- a/tests/test_models/test_backbone.py
+++ b/tests/test_models/test_backbone.py
@@ -87,7 +87,7 @@ def test_resnet_backbone():
             assert param.requires_grad is False
 
     # resnet with depth 50, partial batchnorm
-    resnet_pbn = ResNet(50, partial_bn=True)
+    resnet_pbn = ResNet(50, norm_eval=True, partial_bn=True)
     resnet_pbn.train()
     count_bn = 0
     for m in resnet_pbn.modules():


### PR DESCRIPTION
Actually, the default value of norm_eval should be False. 
Thus if a user forgets to set this arg, the training is still OK.