### PR TITLE
[Feature] Add init_eval to evaluation hook

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@
 
 **New Features**
 - Support the training of video recognition dataset with multiple tag categories ([#235](https://github.com/open-mmlab/mmaction2/pull/235))
+- Support specify a start epoch to conduct evaluation ([216](https://github.com/open-mmlab/mmaction2/pull/216))
 
 **Improvements**
 - Set default values of 'average_clips' in each config file so that there is no need to set it explicitly during testing in most cases ([#232](https://github.com/open-mmlab/mmaction2/pull/232))

--- a/docs/tutorials/customize_runtime.md
+++ b/docs/tutorials/customize_runtime.md
@@ -166,7 +166,7 @@ We support many other learning rate schedule [here](https://github.com/open-mmla
 
 ## Customize Workflow
 
-By defult, we recommend users to use `EvalHook` to do evaluation after training epoch, but they can still use `val` workflow as an alternative.
+By default, we recommend users to use `EpochEvalHook` to do evaluation after training epoch, but they can still use `val` workflow as an alternative.
 
 Workflow is a list of (phase, epochs) to specify the running order and epochs. By default it is set to be
 
@@ -188,7 +188,7 @@ so that 1 epoch for training and 1 epoch for validation will be run iteratively.
 
 1. The parameters of model will not be updated during val epoch.
 2. Keyword `total_epochs` in the config only controls the number of training epochs and will not affect the validation workflow.
-3. Workflows `[('train', 1), ('val', 1)]` and `[('train', 1)]` will not change the behavior of `EvalHook` because `EvalHook` is called by `after_train_epoch` and validation workflow only affect hooks that are called through `after_val_epoch`.
+3. Workflows `[('train', 1), ('val', 1)]` and `[('train', 1)]` will not change the behavior of `EpochEvalHook` because `EpochEvalHook` is called by `after_train_epoch` and validation workflow only affect hooks that are called through `after_val_epoch`.
 Therefore, the only difference between `[('train', 1), ('val', 1)]` and ``[('train', 1)]`` is that the runner will calculate losses on validation set after each training epoch.
 
 ## Customize Hooks
@@ -320,7 +320,7 @@ log_config = dict(
 
 #### Evaluation config
 
-The config of `evaluation` will be used to initialize the [`EvalHook`](https://github.com/open-mmlab/mmaction2/blob/master/mmaction/core/evaluation/eval_hooks.py#L11).
+The config of `evaluation` will be used to initialize the [`EpochEvalHook`](https://github.com/open-mmlab/mmaction2/blob/master/mmaction/core/evaluation/eval_hooks.py#L12).
 Except the key `interval`, other arguments such as `metrics` will be passed to the `dataset.evaluate()`
 
 ```python

--- a/mmaction/apis/train.py
+++ b/mmaction/apis/train.py
@@ -4,7 +4,7 @@ from mmcv.runner import (DistSamplerSeedHook, EpochBasedRunner, OptimizerHook,
                          build_optimizer)
 from mmcv.runner.hooks import Fp16OptimizerHook
 
-from ..core import DistEvalHook, EvalHook
+from ..core import DistEpochEvalHook, EpochEvalHook
 from ..datasets import build_dataloader, build_dataset
 from ..utils import get_root_logger
 
@@ -102,7 +102,7 @@ def train_model(model,
         dataloader_setting = dict(dataloader_setting,
                                   **cfg.data.get('val_dataloader', {}))
         val_dataloader = build_dataloader(val_dataset, **dataloader_setting)
-        eval_hook = DistEvalHook if distributed else EvalHook
+        eval_hook = DistEpochEvalHook if distributed else EpochEvalHook
         runner.register_hook(eval_hook(val_dataloader, **eval_cfg))
 
     if cfg.resume_from:

--- a/mmaction/core/evaluation/__init__.py
+++ b/mmaction/core/evaluation/__init__.py
@@ -5,12 +5,13 @@ from .accuracy import (average_precision_at_temporal_iou,
                        mmit_mean_average_precision, pairwise_temporal_iou,
                        softmax, top_k_accuracy)
 from .eval_detection import ActivityNetDetection
-from .eval_hooks import DistEvalHook, EvalHook
+from .eval_hooks import DistEpochEvalHook, EpochEvalHook
 
 __all__ = [
-    'DistEvalHook', 'EvalHook', 'top_k_accuracy', 'mean_class_accuracy',
-    'confusion_matrix', 'mean_average_precision', 'get_weighted_score',
-    'average_recall_at_avg_proposals', 'pairwise_temporal_iou',
-    'average_precision_at_temporal_iou', 'ActivityNetDetection', 'softmax',
-    'interpolated_precision_recall', 'mmit_mean_average_precision'
+    'DistEpochEvalHook', 'EpochEvalHook', 'top_k_accuracy',
+    'mean_class_accuracy', 'confusion_matrix', 'mean_average_precision',
+    'get_weighted_score', 'average_recall_at_avg_proposals',
+    'pairwise_temporal_iou', 'average_precision_at_temporal_iou',
+    'ActivityNetDetection', 'softmax', 'interpolated_precision_recall',
+    'mmit_mean_average_precision'
 ]

--- a/mmaction/core/evaluation/eval_hooks.py
+++ b/mmaction/core/evaluation/eval_hooks.py
@@ -9,11 +9,11 @@ from torch.utils.data import DataLoader
 from mmaction.utils import get_root_logger
 
 
-class EvalHook(Hook):
-    """Non-Distributed evaluation hook.
+class EpochEvalHook(Hook):
+    """Non-Distributed evaluation hook based on epochs.
 
     Notes:
-        If new arguments are added for EvalHook, tools/test.py,
+        If new arguments are added for EpochEvalHook, tools/test.py,
         tools/eval_metric.py may be effected.
 
     This hook will regularly perform evaluation in a given interval when
@@ -182,8 +182,8 @@ class EvalHook(Hook):
             return None
 
 
-class DistEvalHook(EvalHook):
-    """Distributed evaluation hook.
+class DistEpochEvalHook(EpochEvalHook):
+    """Distributed evaluation hook based on epochs.
 
     This hook will regularly perform evaluation in a given interval when
     performing in distributed environment.

--- a/mmaction/core/evaluation/eval_hooks.py
+++ b/mmaction/core/evaluation/eval_hooks.py
@@ -21,10 +21,10 @@ class EpochEvalHook(Hook):
 
     Args:
         dataloader (DataLoader): A PyTorch dataloader.
-        start (int, optional): Evaluation starting epoch. It enables evaluation
-            before the training starts if ``start`` <= the resuming epoch.
-            If None, whether to evaluate is merely decided by ``interval``.
-            Default: None.
+        start (int | None, optional): Evaluation starting epoch. It enables
+            evaluation before the training starts if ``start`` <= the resuming
+            epoch. If None, whether to evaluate is merely decided by
+            ``interval``. Default: None.
         interval (int): Evaluation interval (by epochs). Default: 1.
         save_best (bool): Whether to save best checkpoint during evaluation.
             Default: True.
@@ -190,13 +190,11 @@ class DistEpochEvalHook(EpochEvalHook):
 
     Args:
         dataloader (DataLoader): A PyTorch dataloader.
-        start (int, optional): Evaluation starting epoch. It enables evaluation
-            before the training starts if ``start`` <= the resuming epoch.
-            If None, whether to evaluate is merely decided by ``interval``.
-            Default: None.
+        start (int | None, optional): Evaluation starting epoch. It enables
+            evaluation before the training starts if ``start`` <= the resuming
+            epoch. If None, whether to evaluate is merely decided by
+            ``interval``. Default: None.
         interval (int): Evaluation interval (by epochs). Default: 1.
-        tmpdir (str | None): Temporary directory to save the results of all
-            processes. Default: None.
         save_best (bool): Whether to save best checkpoint during evaluation.
             Default: True.
         key_indicator (str | None): Key indicator to measure the best
@@ -210,6 +208,10 @@ class DistEpochEvalHook(EpochEvalHook):
         rule (str | None): Comparison rule for best score. Options are None,
             'greater' and 'less'. If set to None, it will infer a reasonable
             rule. Default: 'None'.
+        tmpdir (str | None): Temporary directory to save the results of all
+            processes. Default: None.
+        gpu_collect (bool): Whether to use gpu or cpu to collect results.
+            Default: False.
         **eval_kwargs: Evaluation arguments fed into the evaluate function of
             the dataset.
     """

--- a/mmaction/core/evaluation/eval_hooks.py
+++ b/mmaction/core/evaluation/eval_hooks.py
@@ -207,8 +207,9 @@ class DistEvalHook(EvalHook):
             for action recognition dataset (RawframeDataset and VideoDataset).
             ``AR@AN``, ``auc`` for action localization dataset
             (ActivityNetDataset). Default: `top1_acc`.
-        rule (str | None): Comparison rule for best score. If set to None,
-            it will infer a reasonable rule. Default: 'None'.
+        rule (str | None): Comparison rule for best score. Options are None,
+            'greater' and 'less'. If set to None, it will infer a reasonable
+            rule. Default: 'None'.
         **eval_kwargs: Evaluation arguments fed into the evaluate function of
             the dataset.
     """

--- a/mmaction/core/evaluation/eval_hooks.py
+++ b/mmaction/core/evaluation/eval_hooks.py
@@ -12,6 +12,10 @@ from mmaction.utils import get_root_logger
 class EvalHook(Hook):
     """Non-Distributed evaluation hook.
 
+    Notes:
+        If new arguments are added for EvalHook, tools/test.py,
+        tools/eval_metric.py may be effected.
+
     This hook will regularly perform evaluation in a given interval when
     performing in non-distributed environment.
 
@@ -22,8 +26,6 @@ class EvalHook(Hook):
             If None, whether to evaluate is merely decided by ``interval``.
             Default: None.
         interval (int): Evaluation interval (by epochs). Default: 1.
-        gpu_collect (bool): Whether to use gpu or cpu to collect results.
-            Default: False.
         save_best (bool): Whether to save best checkpoint during evaluation.
             Default: True.
         key_indicator (str | None): Key indicator to measure the best
@@ -56,6 +58,9 @@ class EvalHook(Hook):
         if not isinstance(dataloader, DataLoader):
             raise TypeError(f'dataloader must be a pytorch DataLoader, '
                             f'but got {type(dataloader)}')
+        if not isinstance(save_best, bool):
+            raise TypeError("'save_best' should be a boolean")
+
         if save_best and not key_indicator:
             raise ValueError('key_indicator should not be None, when '
                              'save_best is set to True.')

--- a/mmaction/core/evaluation/eval_hooks.py
+++ b/mmaction/core/evaluation/eval_hooks.py
@@ -36,8 +36,9 @@ class EvalHook(Hook):
             for action recognition dataset (RawframeDataset and VideoDataset).
             ``AR@AN``, ``auc`` for action localization dataset
             (ActivityNetDataset). Default: `top1_acc`.
-        rule (str | None): Comparison rule for best score. If set to None,
-            it will infer a reasonable rule. Default: 'None'.
+        rule (str | None): Comparison rule for best score. Options are None,
+            'greater' and 'less'. If set to None, it will infer a reasonable
+            rule. Default: 'None'.
         **eval_kwargs: Evaluation arguments fed into the evaluate function of
             the dataset.
     """

--- a/mmaction/core/evaluation/eval_hooks.py
+++ b/mmaction/core/evaluation/eval_hooks.py
@@ -17,6 +17,10 @@ class EvalHook(Hook):
 
     Args:
         dataloader (DataLoader): A PyTorch dataloader.
+        start (int, optional): Evaluation starting epoch. It enables evaluation
+            before the training starts if ``start`` <= the resuming epoch.
+            If None, whether to evaluate is merely decided by ``interval``.
+            Default: None.
         interval (int): Evaluation interval (by epochs). Default: 1.
         gpu_collect (bool): Whether to use gpu or cpu to collect results.
             Default: False.
@@ -32,7 +36,8 @@ class EvalHook(Hook):
             (ActivityNetDataset). Default: `top1_acc`.
         rule (str | None): Comparison rule for best score. If set to None,
             it will infer a reasonable rule. Default: 'None'.
-        eval_kwargs (dict, optional): Arguments for evaluation.
+        **eval_kwargs: Evaluation arguments fed into the evaluate function of
+            the dataset.
     """
 
     rule_map = {'greater': lambda x, y: x > y, 'less': lambda x, y: x < y}
@@ -42,8 +47,8 @@ class EvalHook(Hook):
 
     def __init__(self,
                  dataloader,
+                 start=None,
                  interval=1,
-                 gpu_collect=False,
                  save_best=True,
                  key_indicator='top1_acc',
                  rule=None,
@@ -69,9 +74,17 @@ class EvalHook(Hook):
                     f'or in {self.less_keys} when rule is None, '
                     f'but got {key_indicator}')
 
+        if not interval > 0:
+            raise ValueError(f'interval must be positive, but got {interval}')
+        if start is not None and start < 0:
+            warnings.warn(
+                f'The evaluation start epoch {start} is smaller than 0, '
+                f'use 0 instead', UserWarning)
+            start = 0
+
         self.dataloader = dataloader
         self.interval = interval
-        self.gpu_collect = gpu_collect
+        self.start = start
         self.eval_kwargs = eval_kwargs
         self.save_best = save_best
         self.key_indicator = key_indicator
@@ -84,10 +97,38 @@ class EvalHook(Hook):
             self.best_score = self.init_value_map[self.rule]
 
         self.best_json = dict()
+        self.initial_epoch_flag = True
+
+    def before_train_epoch(self, runner):
+        """Evaluate the model only at the start of training."""
+        if not self.initial_epoch_flag:
+            return
+        if self.start is not None and runner.epoch >= self.start:
+            self.after_train_epoch(runner)
+        self.initial_epoch_flag = False
+
+    def evaluation_flag(self, runner):
+        """Judge whether to perform_evaluation after this epoch.
+
+        Returns:
+            bool: The flag indicating whether to perform evaluation.
+        """
+        if self.start is None:
+            if not self.every_n_epochs(runner, self.interval):
+                # No evaluation during the interval epochs.
+                return False
+        elif (runner.epoch + 1) < self.start:
+            # No evaluation if start is larger than the current epoch.
+            return False
+        else:
+            # Evaluation only at epochs 3, 5, 7... if start==3 and interval==2
+            if (runner.epoch + 1 - self.start) % self.interval:
+                return False
+        return True
 
     def after_train_epoch(self, runner):
         """Called after every training epoch to evaluate the results."""
-        if not self.every_n_epochs(runner, self.interval):
+        if not self.evaluation_flag(runner):
             return
 
         current_ckpt_path = osp.join(runner.work_dir,
@@ -143,9 +184,13 @@ class DistEvalHook(EvalHook):
 
     Args:
         dataloader (DataLoader): A PyTorch dataloader.
+        start (int, optional): Evaluation starting epoch. It enables evaluation
+            before the training starts if ``start`` <= the resuming epoch.
+            If None, whether to evaluate is merely decided by ``interval``.
+            Default: None.
         interval (int): Evaluation interval (by epochs). Default: 1.
-        gpu_collect (bool): Whether to use gpu or cpu to collect results.
-            Default: False.
+        tmpdir (str | None): Temporary directory to save the results of all
+            processes. Default: None.
         save_best (bool): Whether to save best checkpoint during evaluation.
             Default: True.
         key_indicator (str | None): Key indicator to measure the best
@@ -158,12 +203,34 @@ class DistEvalHook(EvalHook):
             (ActivityNetDataset). Default: `top1_acc`.
         rule (str | None): Comparison rule for best score. If set to None,
             it will infer a reasonable rule. Default: 'None'.
-        eval_kwargs (dict, optional): Arguments for evaluation.
+        **eval_kwargs: Evaluation arguments fed into the evaluate function of
+            the dataset.
     """
+
+    def __init__(self,
+                 dataloader,
+                 start=None,
+                 interval=1,
+                 save_best=True,
+                 key_indicator='top1_acc',
+                 rule=None,
+                 tmpdir=None,
+                 gpu_collect=False,
+                 **eval_kwargs):
+        super().__init__(
+            dataloader,
+            start=start,
+            interval=interval,
+            save_best=save_best,
+            key_indicator=key_indicator,
+            rule=rule,
+            **eval_kwargs)
+        self.tmpdir = tmpdir
+        self.gpu_collect = gpu_collect
 
     def after_train_epoch(self, runner):
         """Called after each training epoch to evaluate the model."""
-        if not self.every_n_epochs(runner, self.interval):
+        if not self.evaluation_flag(runner):
             return
 
         current_ckpt_path = osp.join(runner.work_dir,
@@ -177,10 +244,15 @@ class DistEvalHook(EvalHook):
             self.key_indicator = self.best_json['key_indicator']
 
         from mmaction.apis import multi_gpu_test
+
+        tmpdir = self.tmpdir
+        if tmpdir is None:
+            tmpdir = osp.join(runner.work_dir, '.eval_hook')
+
         results = multi_gpu_test(
             runner.model,
             self.dataloader,
-            tmpdir=osp.join(runner.work_dir, '.eval_hook'),
+            tmpdir=tmpdir,
             gpu_collect=self.gpu_collect)
         if runner.rank == 0:
             print('\n')

--- a/tests/test_eval_hook.py
+++ b/tests/test_eval_hook.py
@@ -91,6 +91,17 @@ def _build_demo_runner():
     not torch.cuda.is_available(), reason='requires CUDA support')
 def test_eval_hook():
     with pytest.raises(TypeError):
+        # `save_best` should be a boolean
+        test_dataset = ExampleModel()
+        data_loader = DataLoader(
+            test_dataset,
+            batch_size=1,
+            sampler=None,
+            num_workers=0,
+            shuffle=False)
+        EvalHook(data_loader, save_best='True')
+
+    with pytest.raises(TypeError):
         # dataloader must be a pytorch DataLoader
         test_dataset = ExampleModel()
         data_loader = [

--- a/tests/test_eval_hook.py
+++ b/tests/test_eval_hook.py
@@ -299,7 +299,7 @@ def test_start_param(EvalHookParam):
 
     # 1. start=None, interval=1: perform evaluation after each epoch.
     runner = _build_demo_runner()
-    evalhook = EvalHookParam(dataloader, interval=1)
+    evalhook = EvalHookParam(dataloader, interval=1, save_best=False)
     evalhook.evaluate = MagicMock()
     runner.register_hook(evalhook)
     runner.run([dataloader], [('train', 1)], 2)
@@ -307,7 +307,7 @@ def test_start_param(EvalHookParam):
 
     # 2. start=1, interval=1: perform evaluation after each epoch.
     runner = _build_demo_runner()
-    evalhook = EvalHookParam(dataloader, start=1, interval=1)
+    evalhook = EvalHookParam(dataloader, start=1, interval=1, save_best=False)
     evalhook.evaluate = MagicMock()
     runner.register_hook(evalhook)
     runner.run([dataloader], [('train', 1)], 2)
@@ -315,7 +315,7 @@ def test_start_param(EvalHookParam):
 
     # 3. start=None, interval=2: perform evaluation after epoch 2, 4, 6, etc
     runner = _build_demo_runner()
-    evalhook = EvalHookParam(dataloader, interval=2)
+    evalhook = EvalHookParam(dataloader, interval=2, save_best=False)
     evalhook.evaluate = MagicMock()
     runner.register_hook(evalhook)
     runner.run([dataloader], [('train', 1)], 2)
@@ -323,7 +323,7 @@ def test_start_param(EvalHookParam):
 
     # 4. start=1, interval=2: perform evaluation after epoch 1, 3, 5, etc
     runner = _build_demo_runner()
-    evalhook = EvalHookParam(dataloader, start=1, interval=2)
+    evalhook = EvalHookParam(dataloader, start=1, interval=2, save_best=False)
     evalhook.evaluate = MagicMock()
     runner.register_hook(evalhook)
     runner.run([dataloader], [('train', 1)], 3)
@@ -332,7 +332,7 @@ def test_start_param(EvalHookParam):
     # 5. start=0/negative, interval=1: perform evaluation after each epoch and
     #    before epoch 1.
     runner = _build_demo_runner()
-    evalhook = EvalHookParam(dataloader, start=0)
+    evalhook = EvalHookParam(dataloader, start=0, save_best=False)
     evalhook.evaluate = MagicMock()
     runner.register_hook(evalhook)
     runner.run([dataloader], [('train', 1)], 2)
@@ -340,7 +340,7 @@ def test_start_param(EvalHookParam):
 
     runner = _build_demo_runner()
     with pytest.warns(UserWarning):
-        evalhook = EvalHookParam(dataloader, start=-2)
+        evalhook = EvalHookParam(dataloader, start=-2, save_best=False)
     evalhook.evaluate = MagicMock()
     runner.register_hook(evalhook)
     runner.run([dataloader], [('train', 1)], 2)
@@ -349,7 +349,7 @@ def test_start_param(EvalHookParam):
     # 6. resuming from epoch i, start = x (x<=i), interval =1: perform
     #    evaluation after each epoch and before the first epoch.
     runner = _build_demo_runner()
-    evalhook = EvalHookParam(dataloader, start=1)
+    evalhook = EvalHookParam(dataloader, start=1, save_best=False)
     evalhook.evaluate = MagicMock()
     runner.register_hook(evalhook)
     runner._epoch = 2
@@ -359,7 +359,7 @@ def test_start_param(EvalHookParam):
     # 7. resuming from epoch i, start = i+1/None, interval =1: perform
     #    evaluation after each epoch.
     runner = _build_demo_runner()
-    evalhook = EvalHookParam(dataloader, start=2)
+    evalhook = EvalHookParam(dataloader, start=2, save_best=False)
     evalhook.evaluate = MagicMock()
     runner.register_hook(evalhook)
     runner._epoch = 1

--- a/tools/analysis/eval_metric.py
+++ b/tools/analysis/eval_metric.py
@@ -51,7 +51,7 @@ def main():
 
     kwargs = {} if args.eval_options is None else args.eval_options
     eval_kwargs = cfg.get('evaluation', {}).copy()
-    # hard-code way to remove EvalHook args
+    # hard-code way to remove EpochEvalHook args
     for key in [
             'interval', 'tmpdir', 'start', 'gpu_collect', 'save_best', 'rule',
             'key_indicator'


### PR DESCRIPTION
1. Add `start` argument in `xxEvalHook` to indicate the start time for evaluation
2. Add prefix `Epoch` to indicate the current `EvalHook` is based on epochs