### PR TITLE
[Improvement] set default batch_size of evaluation and testing to 1

### DIFF
--- a/mmaction/apis/train.py
+++ b/mmaction/apis/train.py
@@ -119,7 +119,7 @@ def train_model(model,
         eval_cfg = cfg.get('evaluation', {})
         val_dataset = build_dataset(cfg.data.val, dict(test_mode=True))
         dataloader_setting = dict(
-            videos_per_gpu=cfg.data.get('videos_per_gpu', 2),
+            videos_per_gpu=1,
             workers_per_gpu=cfg.data.get('workers_per_gpu', 0),
             # cfg.gpus will be ignored if distributed
             num_gpus=len(cfg.gpu_ids),

--- a/mmaction/apis/train.py
+++ b/mmaction/apis/train.py
@@ -119,7 +119,7 @@ def train_model(model,
         eval_cfg = cfg.get('evaluation', {})
         val_dataset = build_dataset(cfg.data.val, dict(test_mode=True))
         dataloader_setting = dict(
-            videos_per_gpu=1,
+            videos_per_gpu=cfg.data.get('videos_per_gpu', 1),
             workers_per_gpu=cfg.data.get('workers_per_gpu', 0),
             # cfg.gpus will be ignored if distributed
             num_gpus=len(cfg.gpu_ids),

--- a/mmaction/apis/train.py
+++ b/mmaction/apis/train.py
@@ -120,7 +120,7 @@ def train_model(model,
         val_dataset = build_dataset(cfg.data.val, dict(test_mode=True))
         dataloader_setting = dict(
             videos_per_gpu=cfg.data.get('videos_per_gpu', 1),
-            workers_per_gpu=cfg.data.get('workers_per_gpu', 0),
+            workers_per_gpu=cfg.data.get('workers_per_gpu', 1),
             # cfg.gpus will be ignored if distributed
             num_gpus=len(cfg.gpu_ids),
             dist=distributed,

--- a/tools/test.py
+++ b/tools/test.py
@@ -53,10 +53,6 @@ def parse_args():
         'in xxx=yyy format will be merged into config file. For example, '
         "'--cfg-options model.backbone.depth=18 model.backbone.with_cp=True'")
     parser.add_argument(
-        '--multi-batches',
-        action='store_true',
-        help='whether to perform multi batches inference')
-    parser.add_argument(
         '--average-clips',
         choices=['score', 'prob', None],
         default=None,
@@ -132,8 +128,7 @@ def main():
     # build the dataloader
     dataset = build_dataset(cfg.data.test, dict(test_mode=True))
     dataloader_setting = dict(
-        videos_per_gpu=cfg.data.get('videos_per_gpu', 1)
-        if args.multi_batches else 1,
+        videos_per_gpu=cfg.data.get('videos_per_gpu', 1),
         workers_per_gpu=cfg.data.get('workers_per_gpu', 0),
         dist=distributed,
         shuffle=False)

--- a/tools/test.py
+++ b/tools/test.py
@@ -128,7 +128,7 @@ def main():
     # build the dataloader
     dataset = build_dataset(cfg.data.test, dict(test_mode=True))
     dataloader_setting = dict(
-        videos_per_gpu=cfg.data.get('videos_per_gpu', 2),
+        videos_per_gpu=1,
         workers_per_gpu=cfg.data.get('workers_per_gpu', 0),
         dist=distributed,
         shuffle=False)

--- a/tools/test.py
+++ b/tools/test.py
@@ -129,7 +129,7 @@ def main():
     dataset = build_dataset(cfg.data.test, dict(test_mode=True))
     dataloader_setting = dict(
         videos_per_gpu=cfg.data.get('videos_per_gpu', 1),
-        workers_per_gpu=cfg.data.get('workers_per_gpu', 0),
+        workers_per_gpu=cfg.data.get('workers_per_gpu', 1),
         dist=distributed,
         shuffle=False)
     dataloader_setting = dict(dataloader_setting,

--- a/tools/test.py
+++ b/tools/test.py
@@ -53,6 +53,10 @@ def parse_args():
         'in xxx=yyy format will be merged into config file. For example, '
         "'--cfg-options model.backbone.depth=18 model.backbone.with_cp=True'")
     parser.add_argument(
+        '--multi-batches',
+        action='store_true',
+        help='whether to perform multi batches inference')
+    parser.add_argument(
         '--average-clips',
         choices=['score', 'prob', None],
         default=None,
@@ -128,7 +132,8 @@ def main():
     # build the dataloader
     dataset = build_dataset(cfg.data.test, dict(test_mode=True))
     dataloader_setting = dict(
-        videos_per_gpu=1,
+        videos_per_gpu=cfg.data.get('videos_per_gpu', 1)
+        if args.multi_batches else 1,
         workers_per_gpu=cfg.data.get('workers_per_gpu', 0),
         dist=distributed,
         shuffle=False)


### PR DESCRIPTION
This PR sets default batch_size of evaluation and testing as 1 to avoid OOM and manual config changes in most cases, since it used the training `batch_size` as default when `videos_per_gpu=cfg.data.get('videos_per_gpu', 2)`