### PR TITLE
[Improve] Use metric_dict to replace hardcode arg in `evaluate`

### DIFF
--- a/configs/recognition/c3d/c3d_sports1m_16x1x1_45e_ucf101_rgb.py
+++ b/configs/recognition/c3d/c3d_sports1m_16x1x1_45e_ucf101_rgb.py
@@ -102,7 +102,7 @@ lr_config = dict(policy='step', step=[20, 40])
 total_epochs = 45
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/csn/ircsn_ig65m_pretrained_bnfrozen_r152_32x2x1_58e_kinetics400_rgb.py
+++ b/configs/recognition/csn/ircsn_ig65m_pretrained_bnfrozen_r152_32x2x1_58e_kinetics400_rgb.py
@@ -109,7 +109,7 @@ lr_config = dict(
 total_epochs = 58
 checkpoint_config = dict(interval=2)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[dict(type='TextLoggerHook'),

--- a/configs/recognition/csn/ircsn_ig65m_pretrained_r152_32x2x1_58e_kinetics400_rgb.py
+++ b/configs/recognition/csn/ircsn_ig65m_pretrained_r152_32x2x1_58e_kinetics400_rgb.py
@@ -108,7 +108,7 @@ lr_config = dict(
 total_epochs = 58
 checkpoint_config = dict(interval=2)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[dict(type='TextLoggerHook'),

--- a/configs/recognition/i3d/i3d_nl_dot_product_r50_32x2x1_100e_kinetics400_rgb.py
+++ b/configs/recognition/i3d/i3d_nl_dot_product_r50_32x2x1_100e_kinetics400_rgb.py
@@ -112,7 +112,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/i3d/i3d_nl_embedded_gaussian_r50_32x2x1_100e_kinetics400_rgb.py
+++ b/configs/recognition/i3d/i3d_nl_embedded_gaussian_r50_32x2x1_100e_kinetics400_rgb.py
@@ -112,7 +112,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/i3d/i3d_nl_gaussian_r50_32x2x1_100e_kinetics400_rgb.py
+++ b/configs/recognition/i3d/i3d_nl_gaussian_r50_32x2x1_100e_kinetics400_rgb.py
@@ -112,7 +112,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/i3d/i3d_r50_32x2x1_100e_kinetics400_rgb.py
+++ b/configs/recognition/i3d/i3d_r50_32x2x1_100e_kinetics400_rgb.py
@@ -106,7 +106,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/i3d/i3d_r50_dense_32x2x1_100e_kinetics400_rgb.py
+++ b/configs/recognition/i3d/i3d_r50_dense_32x2x1_100e_kinetics400_rgb.py
@@ -106,7 +106,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/i3d/i3d_r50_heavy_8x8x1_100e_kinetics400_rgb.py
+++ b/configs/recognition/i3d/i3d_r50_heavy_8x8x1_100e_kinetics400_rgb.py
@@ -109,7 +109,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/i3d/i3d_r50_lazy_32x2x1_100e_kinetics400_rgb.py
+++ b/configs/recognition/i3d/i3d_r50_lazy_32x2x1_100e_kinetics400_rgb.py
@@ -108,7 +108,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/configs/recognition/i3d/i3d_r50_video_32x2x1_100e_kinetics400_rgb.py
+++ b/configs/recognition/i3d/i3d_r50_video_32x2x1_100e_kinetics400_rgb.py
@@ -109,7 +109,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/i3d/i3d_r50_video_heavy_8x8x1_100e_kinetics400_rgb.py
+++ b/configs/recognition/i3d/i3d_r50_video_heavy_8x8x1_100e_kinetics400_rgb.py
@@ -112,7 +112,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/r2plus1d/r2plus1d_r34_32x2x1_180e_kinetics400_rgb.py
+++ b/configs/recognition/r2plus1d/r2plus1d_r34_32x2x1_180e_kinetics400_rgb.py
@@ -109,7 +109,7 @@ lr_config = dict(policy='CosineAnnealing', min_lr=0)
 total_epochs = 180
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/r2plus1d/r2plus1d_r34_8x8x1_180e_kinetics400_rgb.py
+++ b/configs/recognition/r2plus1d/r2plus1d_r34_8x8x1_180e_kinetics400_rgb.py
@@ -109,7 +109,7 @@ lr_config = dict(policy='CosineAnnealing', min_lr=0)
 total_epochs = 180
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/r2plus1d/r2plus1d_r34_video_8x8x1_180e_kinetics400_rgb.py
+++ b/configs/recognition/r2plus1d/r2plus1d_r34_video_8x8x1_180e_kinetics400_rgb.py
@@ -113,7 +113,7 @@ lr_config = dict(policy='CosineAnnealing', min_lr=0)
 total_epochs = 180
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/slowfast/slowfast_r50_4x16x1_256e_kinetics400_rgb.py
+++ b/configs/recognition/slowfast/slowfast_r50_4x16x1_256e_kinetics400_rgb.py
@@ -121,7 +121,7 @@ total_epochs = 256
 checkpoint_config = dict(interval=4)
 workflow = [('train', 1)]
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/slowfast/slowfast_r50_8x8x1_256e_kinetics400_rgb.py
+++ b/configs/recognition/slowfast/slowfast_r50_8x8x1_256e_kinetics400_rgb.py
@@ -122,7 +122,7 @@ total_epochs = 256
 checkpoint_config = dict(interval=4)
 workflow = [('train', 1)]
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/slowfast/slowfast_r50_video_4x16x1_256e_kinetics400_rgb.py
+++ b/configs/recognition/slowfast/slowfast_r50_video_4x16x1_256e_kinetics400_rgb.py
@@ -124,7 +124,7 @@ total_epochs = 256
 checkpoint_config = dict(interval=4)
 workflow = [('train', 1)]
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/slowonly/data_benchmark/slowonly_r50_randomresizedcrop_256p_4x16x1_256e_kinetics400_rgb.py
+++ b/configs/recognition/slowonly/data_benchmark/slowonly_r50_randomresizedcrop_256p_4x16x1_256e_kinetics400_rgb.py
@@ -99,7 +99,7 @@ total_epochs = 256
 checkpoint_config = dict(interval=4)
 workflow = [('train', 1)]
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/slowonly/data_benchmark/slowonly_r50_randomresizedcrop_320p_4x16x1_256e_kinetics400_rgb.py
+++ b/configs/recognition/slowonly/data_benchmark/slowonly_r50_randomresizedcrop_320p_4x16x1_256e_kinetics400_rgb.py
@@ -99,7 +99,7 @@ total_epochs = 256
 checkpoint_config = dict(interval=4)
 workflow = [('train', 1)]
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/slowonly/data_benchmark/slowonly_r50_randomresizedcrop_340x256_4x16x1_256e_kinetics400_rgb.py
+++ b/configs/recognition/slowonly/data_benchmark/slowonly_r50_randomresizedcrop_340x256_4x16x1_256e_kinetics400_rgb.py
@@ -99,7 +99,7 @@ total_epochs = 256
 checkpoint_config = dict(interval=4)
 workflow = [('train', 1)]
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/slowonly/slowonly_imagenet_pretrained_r50_4x16x1_150e_kinetics400_rgb.py
+++ b/configs/recognition/slowonly/slowonly_imagenet_pretrained_r50_4x16x1_150e_kinetics400_rgb.py
@@ -104,7 +104,7 @@ total_epochs = 150
 checkpoint_config = dict(interval=4)
 workflow = [('train', 1)]
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/slowonly/slowonly_imagenet_pretrained_r50_8x8x1_150e_kinetics400_rgb.py
+++ b/configs/recognition/slowonly/slowonly_imagenet_pretrained_r50_8x8x1_150e_kinetics400_rgb.py
@@ -104,7 +104,7 @@ total_epochs = 150
 checkpoint_config = dict(interval=4)
 workflow = [('train', 1)]
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/slowonly/slowonly_r101_8x8x1_196e_kinetics400_rgb.py
+++ b/configs/recognition/slowonly/slowonly_r101_8x8x1_196e_kinetics400_rgb.py
@@ -105,7 +105,7 @@ total_epochs = 196
 checkpoint_config = dict(interval=4)
 workflow = [('train', 1)]
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/configs/recognition/slowonly/slowonly_r50_4x16x1_256e_kinetics400_flow.py
+++ b/configs/recognition/slowonly/slowonly_r50_4x16x1_256e_kinetics400_flow.py
@@ -111,7 +111,7 @@ total_epochs = 256
 checkpoint_config = dict(interval=4)
 workflow = [('train', 1)]
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/slowonly/slowonly_r50_4x16x1_256e_kinetics400_rgb.py
+++ b/configs/recognition/slowonly/slowonly_r50_4x16x1_256e_kinetics400_rgb.py
@@ -99,7 +99,7 @@ total_epochs = 256
 checkpoint_config = dict(interval=4)
 workflow = [('train', 1)]
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/slowonly/slowonly_r50_8x8x1_256e_kinetics400_flow.py
+++ b/configs/recognition/slowonly/slowonly_r50_8x8x1_256e_kinetics400_flow.py
@@ -111,7 +111,7 @@ total_epochs = 196
 checkpoint_config = dict(interval=4)
 workflow = [('train', 1)]
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/slowonly/slowonly_r50_8x8x1_256e_kinetics400_rgb.py
+++ b/configs/recognition/slowonly/slowonly_r50_8x8x1_256e_kinetics400_rgb.py
@@ -99,7 +99,7 @@ total_epochs = 256
 checkpoint_config = dict(interval=4)
 workflow = [('train', 1)]
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/slowonly/slowonly_r50_video_4x16x1_256e_kinetics400_rgb.py
+++ b/configs/recognition/slowonly/slowonly_r50_video_4x16x1_256e_kinetics400_rgb.py
@@ -102,7 +102,7 @@ total_epochs = 256
 checkpoint_config = dict(interval=4)
 workflow = [('train', 1)]
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/slowonly/slowonly_r50_video_8x8x1_256e_kinetics600_rgb.py
+++ b/configs/recognition/slowonly/slowonly_r50_video_8x8x1_256e_kinetics600_rgb.py
@@ -99,7 +99,7 @@ total_epochs = 256
 checkpoint_config = dict(interval=4)
 workflow = [('train', 1)]
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/slowonly/slowonly_r50_video_8x8x1_256e_kinetics700_rgb.py
+++ b/configs/recognition/slowonly/slowonly_r50_video_8x8x1_256e_kinetics700_rgb.py
@@ -99,7 +99,7 @@ total_epochs = 256
 checkpoint_config = dict(interval=4)
 workflow = [('train', 1)]
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tin/tin_r50_1x1x8_40e_sthv1_rgb.py
+++ b/configs/recognition/tin/tin_r50_1x1x8_40e_sthv1_rgb.py
@@ -115,7 +115,7 @@ lr_config = dict(
 total_epochs = 40
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tin/tin_r50_1x1x8_40e_sthv2_rgb.py
+++ b/configs/recognition/tin/tin_r50_1x1x8_40e_sthv2_rgb.py
@@ -115,7 +115,7 @@ lr_config = dict(
 total_epochs = 40
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=2, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=2, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tin/tin_tsm_finetune_r50_1x1x8_50e_kinetics400_rgb.py
+++ b/configs/recognition/tin/tin_tsm_finetune_r50_1x1x8_50e_kinetics400_rgb.py
@@ -108,7 +108,7 @@ lr_config = dict(policy='step', step=[20, 40])
 total_epochs = 50
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tpn/tpn_imagenet_pretrained_slowonly_r50_8x8x1_150e_kinetics_rgb.py
+++ b/configs/recognition/tpn/tpn_imagenet_pretrained_slowonly_r50_8x8x1_150e_kinetics_rgb.py
@@ -116,7 +116,7 @@ lr_config = dict(policy='step', step=[75, 125])
 total_epochs = 150
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tpn/tpn_slowonly_r50_8x8x1_150e_kinetics_rgb.py
+++ b/configs/recognition/tpn/tpn_slowonly_r50_8x8x1_150e_kinetics_rgb.py
@@ -116,7 +116,7 @@ lr_config = dict(policy='step', step=[75, 125])
 total_epochs = 150
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tpn/tpn_tsm_r50_1x1x8_150e_sthv1_rgb.py
+++ b/configs/recognition/tpn/tpn_tsm_r50_1x1x8_150e_sthv1_rgb.py
@@ -112,7 +112,7 @@ lr_config = dict(policy='step', step=[75, 125])
 total_epochs = 150
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsm/tsm_nl_dot_product_r50_1x1x8_50e_kinetics400_rgb.py
+++ b/configs/recognition/tsm/tsm_nl_dot_product_r50_1x1x8_50e_kinetics400_rgb.py
@@ -116,7 +116,7 @@ lr_config = dict(policy='step', step=[20, 40])
 total_epochs = 50
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsm/tsm_nl_embedded_gaussian_r50_1x1x8_50e_kinetics400_rgb.py
+++ b/configs/recognition/tsm/tsm_nl_embedded_gaussian_r50_1x1x8_50e_kinetics400_rgb.py
@@ -116,7 +116,7 @@ lr_config = dict(policy='step', step=[20, 40])
 total_epochs = 50
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsm/tsm_nl_gaussian_r50_1x1x8_50e_kinetics400_rgb.py
+++ b/configs/recognition/tsm/tsm_nl_gaussian_r50_1x1x8_50e_kinetics400_rgb.py
@@ -116,7 +116,7 @@ lr_config = dict(policy='step', step=[20, 40])
 total_epochs = 50
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsm/tsm_r101_1x1x8_50e_sthv1_rgb.py
+++ b/configs/recognition/tsm/tsm_r101_1x1x8_50e_sthv1_rgb.py
@@ -110,7 +110,7 @@ lr_config = dict(policy='step', step=[20, 40])
 total_epochs = 50
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=2, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=2, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsm/tsm_r101_1x1x8_50e_sthv2_rgb.py
+++ b/configs/recognition/tsm/tsm_r101_1x1x8_50e_sthv2_rgb.py
@@ -107,7 +107,7 @@ lr_config = dict(policy='step', step=[20, 40])
 total_epochs = 50
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=2, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=2, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsm/tsm_r50_1x1x16_50e_kinetics400_rgb.py
+++ b/configs/recognition/tsm/tsm_r50_1x1x16_50e_kinetics400_rgb.py
@@ -112,7 +112,7 @@ lr_config = dict(policy='step', step=[20, 40])
 total_epochs = 50
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsm/tsm_r50_1x1x16_50e_sthv1_rgb.py
+++ b/configs/recognition/tsm/tsm_r50_1x1x16_50e_sthv1_rgb.py
@@ -112,7 +112,7 @@ lr_config = dict(policy='step', step=[20, 40])
 total_epochs = 50
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=2, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=2, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsm/tsm_r50_1x1x16_50e_sthv2_rgb.py
+++ b/configs/recognition/tsm/tsm_r50_1x1x16_50e_sthv2_rgb.py
@@ -109,7 +109,7 @@ lr_config = dict(policy='step', step=[20, 40])
 total_epochs = 50
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=2, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=2, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsm/tsm_r50_1x1x8_50e_kinetics400_rgb.py
+++ b/configs/recognition/tsm/tsm_r50_1x1x8_50e_kinetics400_rgb.py
@@ -110,7 +110,7 @@ lr_config = dict(policy='step', step=[20, 40])
 total_epochs = 50
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsm/tsm_r50_1x1x8_50e_sthv1_rgb.py
+++ b/configs/recognition/tsm/tsm_r50_1x1x8_50e_sthv1_rgb.py
@@ -110,7 +110,7 @@ lr_config = dict(policy='step', step=[20, 40])
 total_epochs = 50
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=2, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=2, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsm/tsm_r50_1x1x8_50e_sthv2_rgb.py
+++ b/configs/recognition/tsm/tsm_r50_1x1x8_50e_sthv2_rgb.py
@@ -107,7 +107,7 @@ lr_config = dict(policy='step', step=[20, 40])
 total_epochs = 50
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=2, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=2, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsm/tsm_r50_dense_1x1x8_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsm/tsm_r50_dense_1x1x8_100e_kinetics400_rgb.py
@@ -111,7 +111,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=2, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=2, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsm/tsm_r50_video_1x1x8_50e_kinetics400_rgb.py
+++ b/configs/recognition/tsm/tsm_r50_video_1x1x8_50e_kinetics400_rgb.py
@@ -113,7 +113,7 @@ lr_config = dict(policy='step', step=[20, 40])
 total_epochs = 50
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsm/tsm_temporal_pool_r50_1x1x8_50e_kinetics400_rgb.py
+++ b/configs/recognition/tsm/tsm_temporal_pool_r50_1x1x8_50e_kinetics400_rgb.py
@@ -112,7 +112,7 @@ lr_config = dict(policy='step', step=[20, 40])
 total_epochs = 50
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsn/data_benchmark/tsn_r50_multiscalecrop_256p_1x1x3_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsn/data_benchmark/tsn_r50_multiscalecrop_256p_1x1x3_100e_kinetics400_rgb.py
@@ -101,7 +101,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/configs/recognition/tsn/data_benchmark/tsn_r50_multiscalecrop_320p_1x1x3_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsn/data_benchmark/tsn_r50_multiscalecrop_320p_1x1x3_100e_kinetics400_rgb.py
@@ -101,7 +101,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/configs/recognition/tsn/data_benchmark/tsn_r50_multiscalecrop_340x256_1x1x3_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsn/data_benchmark/tsn_r50_multiscalecrop_340x256_1x1x3_100e_kinetics400_rgb.py
@@ -103,7 +103,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsn/data_benchmark/tsn_r50_randomresizedcrop_256p_1x1x3_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsn/data_benchmark/tsn_r50_randomresizedcrop_256p_1x1x3_100e_kinetics400_rgb.py
@@ -98,7 +98,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsn/data_benchmark/tsn_r50_randomresizedcrop_320p_1x1x3_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsn/data_benchmark/tsn_r50_randomresizedcrop_320p_1x1x3_100e_kinetics400_rgb.py
@@ -98,7 +98,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsn/data_benchmark/tsn_r50_randomresizedcrop_340x256_1x1x3_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsn/data_benchmark/tsn_r50_randomresizedcrop_340x256_1x1x3_100e_kinetics400_rgb.py
@@ -96,7 +96,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/configs/recognition/tsn/tsn_fp16_r50_1x1x3_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsn/tsn_fp16_r50_1x1x3_100e_kinetics400_rgb.py
@@ -103,7 +103,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsn/tsn_r50_1x1x16_50e_sthv1_rgb.py
+++ b/configs/recognition/tsn/tsn_r50_1x1x16_50e_sthv1_rgb.py
@@ -106,7 +106,7 @@ lr_config = dict(policy='step', step=[20, 40])
 total_epochs = 50
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=2, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=2, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsn/tsn_r50_1x1x16_50e_sthv2_rgb.py
+++ b/configs/recognition/tsn/tsn_r50_1x1x16_50e_sthv2_rgb.py
@@ -91,7 +91,7 @@ lr_config = dict(policy='step', step=[20, 40])
 total_epochs = 50
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=2, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=2, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsn/tsn_r50_1x1x3_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsn/tsn_r50_1x1x3_100e_kinetics400_rgb.py
@@ -103,7 +103,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsn/tsn_r50_1x1x3_75e_ucf101_rgb.py
+++ b/configs/recognition/tsn/tsn_r50_1x1x3_75e_ucf101_rgb.py
@@ -99,7 +99,7 @@ lr_config = dict(policy='step', step=[])
 total_epochs = 75
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsn/tsn_r50_1x1x8_50e_sthv1_rgb.py
+++ b/configs/recognition/tsn/tsn_r50_1x1x8_50e_sthv1_rgb.py
@@ -107,7 +107,7 @@ lr_config = dict(policy='step', step=[20, 40])
 total_epochs = 50
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsn/tsn_r50_1x1x8_50e_sthv2_rgb.py
+++ b/configs/recognition/tsn/tsn_r50_1x1x8_50e_sthv2_rgb.py
@@ -93,7 +93,7 @@ lr_config = dict(policy='step', step=[20, 40])
 total_epochs = 50
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsn/tsn_r50_320p_1x1x3_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsn/tsn_r50_320p_1x1x3_100e_kinetics400_rgb.py
@@ -98,7 +98,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsn/tsn_r50_320p_1x1x3_110e_kinetics400_flow.py
+++ b/configs/recognition/tsn/tsn_r50_320p_1x1x3_110e_kinetics400_flow.py
@@ -104,7 +104,7 @@ lr_config = dict(policy='step', step=[70, 100])
 total_epochs = 110
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsn/tsn_r50_320p_1x1x8_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsn/tsn_r50_320p_1x1x8_100e_kinetics400_rgb.py
@@ -98,7 +98,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=2, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=2, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsn/tsn_r50_320p_1x1x8_110e_kinetics400_flow.py
+++ b/configs/recognition/tsn/tsn_r50_320p_1x1x8_110e_kinetics400_flow.py
@@ -104,7 +104,7 @@ lr_config = dict(policy='step', step=[70, 100])
 total_epochs = 110
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsn/tsn_r50_320p_1x1x8_150e_activitynet_clip_flow.py
+++ b/configs/recognition/tsn/tsn_r50_320p_1x1x8_150e_activitynet_clip_flow.py
@@ -109,7 +109,7 @@ lr_config = dict(policy='step', step=[60, 120])
 total_epochs = 150
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsn/tsn_r50_320p_1x1x8_150e_activitynet_video_flow.py
+++ b/configs/recognition/tsn/tsn_r50_320p_1x1x8_150e_activitynet_video_flow.py
@@ -109,7 +109,7 @@ lr_config = dict(policy='step', step=[60, 120])
 total_epochs = 150
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsn/tsn_r50_320p_1x1x8_50e_activitynet_clip_rgb.py
+++ b/configs/recognition/tsn/tsn_r50_320p_1x1x8_50e_activitynet_clip_rgb.py
@@ -106,7 +106,7 @@ lr_config = dict(policy='step', step=[20, 40])
 total_epochs = 50
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsn/tsn_r50_320p_1x1x8_50e_activitynet_video_rgb.py
+++ b/configs/recognition/tsn/tsn_r50_320p_1x1x8_50e_activitynet_video_rgb.py
@@ -106,7 +106,7 @@ lr_config = dict(policy='step', step=[20, 40])
 total_epochs = 50
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsn/tsn_r50_dense_1x1x5_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsn/tsn_r50_dense_1x1x5_100e_kinetics400_rgb.py
@@ -105,7 +105,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=2, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=2, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsn/tsn_r50_dense_1x1x8_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsn/tsn_r50_dense_1x1x8_100e_kinetics400_rgb.py
@@ -104,7 +104,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsn/tsn_r50_video_1x1x8_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsn/tsn_r50_video_1x1x8_100e_kinetics400_rgb.py
@@ -105,7 +105,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsn/tsn_r50_video_1x1x8_100e_kinetics600_rgb.py
+++ b/configs/recognition/tsn/tsn_r50_video_1x1x8_100e_kinetics600_rgb.py
@@ -100,7 +100,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsn/tsn_r50_video_1x1x8_100e_kinetics700_rgb.py
+++ b/configs/recognition/tsn/tsn_r50_video_1x1x8_100e_kinetics700_rgb.py
@@ -100,7 +100,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsn/tsn_r50_video_320p_1x1x3_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsn/tsn_r50_video_320p_1x1x3_100e_kinetics400_rgb.py
@@ -100,7 +100,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition/tsn/tsn_r50_video_dense_1x1x8_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsn/tsn_r50_video_dense_1x1x8_100e_kinetics400_rgb.py
@@ -106,7 +106,7 @@ lr_config = dict(policy='step', step=[40, 80])
 total_epochs = 100
 checkpoint_config = dict(interval=1)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition_audio/resnet/tsn_r18_64x1x1_100e_kinetics400_audio_feature.py
+++ b/configs/recognition_audio/resnet/tsn_r18_64x1x1_100e_kinetics400_audio_feature.py
@@ -80,7 +80,7 @@ lr_config = dict(policy='CosineAnnealing', min_lr=0)
 total_epochs = 100
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition_audio/resnet/tsn_r50_64x1x1_100e_kinetics400_audio.py
+++ b/configs/recognition_audio/resnet/tsn_r50_64x1x1_100e_kinetics400_audio.py
@@ -86,7 +86,7 @@ lr_config = dict(policy='CosineAnnealing', min_lr=0)
 total_epochs = 100
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/configs/recognition_audio/resnet/tsn_r50_64x1x1_100e_kinetics400_audio_feature.py
+++ b/configs/recognition_audio/resnet/tsn_r50_64x1x1_100e_kinetics400_audio_feature.py
@@ -80,7 +80,7 @@ lr_config = dict(policy='CosineAnnealing', min_lr=0)
 total_epochs = 100
 checkpoint_config = dict(interval=5)
 evaluation = dict(
-    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'], topk=(1, 5))
+    interval=5, metrics=['top_k_accuracy', 'mean_class_accuracy'])
 log_config = dict(
     interval=20,
     hooks=[

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,7 @@
 - Set default values of 'average_clips' in each config file so that there is no need to set it explicitly during testing in most cases ([#232](https://github.com/open-mmlab/mmaction2/pull/232))
 - Extend HVU datatools to generate individual file list for each tag category ([#258](https://github.com/open-mmlab/mmaction2/pull/258))
 - Support data preparation for Kinetics-600 and Kinetics-700 ([#254](https://github.com/open-mmlab/mmaction2/pull/254))
+- Use `metric_dict` to replace hardcoded arguments in `evaluate` function ([#286](https://github.com/open-mmlab/mmaction2/pull/286))
 - Add `cfg-options` in arguments to override some settings in the used config for convenience ([#212](https://github.com/open-mmlab/mmaction2/pull/212))
 - Rename the old evaluating protocol `mean_average_precision` as `mmit_mean_average_precision` since it is only used on MMIT and is not the `mAP` we usually talk about. Add `mean_average_precision`, which is the real `mAP` ([#235](https://github.com/open-mmlab/mmaction2/pull/235))
 - Add accurate setting (Three crop * 2 clip) and report corresponding performance for TSM model ([#241](https://github.com/open-mmlab/mmaction2/pull/241))

--- a/mmaction/datasets/activitynet_dataset.py
+++ b/mmaction/datasets/activitynet_dataset.py
@@ -1,6 +1,7 @@
 import copy
 import os
 import os.path as osp
+import warnings
 
 import mmcv
 import numpy as np
@@ -192,7 +193,8 @@ class ActivityNetDataset(BaseDataset):
                     max_avg_proposals=100,
                     temporal_iou_thresholds=np.linspace(0.5, 0.95, 10))
             },
-            logger=None):
+            logger=None,
+            **deprecated_kwargs):
         """Evaluation in feature dataset.
 
         Args:
@@ -205,12 +207,22 @@ class ActivityNetDataset(BaseDataset):
                 default: ``{'AR@AN': dict(max_avg_proposals=100,
                 temporal_iou_thresholds=np.linspace(0.5, 0.95, 10))}``.
             logger (logging.Logger | None): Training logger. Defaults: None.
+            deprecated_kwargs (dict): Used for containing deprecated arguments.
+                See 'https://github.com/open-mmlab/mmaction2/pull/286'.
 
         Returns:
             dict: Evaluation results for evaluation metrics.
         """
         # Protect ``metric_options`` since it uses mutable value as default
         metric_options = copy.deepcopy(metric_options)
+
+        if deprecated_kwargs != {}:
+            warnings.warn(
+                'Option arguments for metrics has been changed to '
+                "`metric_options`, See 'https://github.com/open-mmlab/mmaction2/pull/286' "  # noqa: E501
+                'for more details')
+            metric_options['AR@AN'] = dict(metric_options['AR@AN'],
+                                           **deprecated_kwargs)
 
         if not isinstance(results, list):
             raise TypeError(f'results must be a list, but got {type(results)}')

--- a/mmaction/datasets/activitynet_dataset.py
+++ b/mmaction/datasets/activitynet_dataset.py
@@ -199,7 +199,9 @@ class ActivityNetDataset(BaseDataset):
             results (list[dict]): Output results.
             metrics (str | sequence[str]): Metrics to be performed.
                 Defaults: 'AR@AN'.
-            metric_options (dict): Dict for metric options.
+            metric_options (dict): Dict for metric options. Options are
+                ``max_avg_proposals``, ``temporal_iou_thresholds`` for
+                ``AR@AN``.
             logger (logging.Logger | None): Training logger. Defaults: None.
 
         Returns:
@@ -226,10 +228,11 @@ class ActivityNetDataset(BaseDataset):
 
         for metric in metrics:
             if metric == 'AR@AN':
-                temporal_iou_thresholds = metric_options['AR@AN'].get(
-                    'temporal_iou_thresholds')
-                max_avg_proposals = metric_options['AR@AN'].get(
-                    'max_avg_proposals')
+                temporal_iou_thresholds = metric_options.setdefault(
+                    'AR@AN', {}).setdefault('temporal_iou_thresholds',
+                                            np.linspace(0.5, 0.95, 10))
+                max_avg_proposals = metric_options.setdefault(
+                    'AR@AN', {}).setdefault('max_avg_proposals', 100)
                 if isinstance(temporal_iou_thresholds, list):
                     temporal_iou_thresholds = np.array(temporal_iou_thresholds)
 

--- a/mmaction/datasets/activitynet_dataset.py
+++ b/mmaction/datasets/activitynet_dataset.py
@@ -201,6 +201,9 @@ class ActivityNetDataset(BaseDataset):
         Returns:
             dict: Evaluation results for evaluation metrics.
         """
+        # Protect ``metric_dict`` since it use immutable value as default
+        metric_dict = copy.deepcopy(metric_dict)
+
         if not isinstance(results, list):
             raise TypeError(f'results must be a list, but got {type(results)}')
         assert len(results) == len(self), (

--- a/mmaction/datasets/activitynet_dataset.py
+++ b/mmaction/datasets/activitynet_dataset.py
@@ -182,27 +182,31 @@ class ActivityNetDataset(BaseDataset):
             raise ValueError(
                 f'The output format {output_format} is not supported.')
 
-    def evaluate(self,
-                 results,
-                 metrics='AR@AN',
-                 metric_dict=dict(
-                     max_avg_proposals=100,
-                     temporal_iou_thresholds=np.linspace(0.5, 0.95, 10)),
-                 logger=None):
+    def evaluate(
+            self,
+            results,
+            metrics='AR@AN',
+            metric_options={
+                'AR@AN':
+                dict(
+                    max_avg_proposals=100,
+                    temporal_iou_thresholds=np.linspace(0.5, 0.95, 10))
+            },
+            logger=None):
         """Evaluation in feature dataset.
 
         Args:
             results (list[dict]): Output results.
             metrics (str | sequence[str]): Metrics to be performed.
                 Defaults: 'AR@AN'.
-            metric_dict (dict): Dict for metric options.
+            metric_options (dict): Dict for metric options.
             logger (logging.Logger | None): Training logger. Defaults: None.
 
         Returns:
             dict: Evaluation results for evaluation metrics.
         """
-        # Protect ``metric_dict`` since it uses mutable value as default
-        metric_dict = copy.deepcopy(metric_dict)
+        # Protect ``metric_options`` since it uses mutable value as default
+        metric_options = copy.deepcopy(metric_options)
 
         if not isinstance(results, list):
             raise TypeError(f'results must be a list, but got {type(results)}')
@@ -222,9 +226,10 @@ class ActivityNetDataset(BaseDataset):
 
         for metric in metrics:
             if metric == 'AR@AN':
-                temporal_iou_thresholds = metric_dict.get(
+                temporal_iou_thresholds = metric_options['AR@AN'].get(
                     'temporal_iou_thresholds')
-                max_avg_proposals = metric_dict.get('max_avg_proposals')
+                max_avg_proposals = metric_options['AR@AN'].get(
+                    'max_avg_proposals')
                 if isinstance(temporal_iou_thresholds, list):
                     temporal_iou_thresholds = np.array(temporal_iou_thresholds)
 

--- a/mmaction/datasets/activitynet_dataset.py
+++ b/mmaction/datasets/activitynet_dataset.py
@@ -202,6 +202,8 @@ class ActivityNetDataset(BaseDataset):
             metric_options (dict): Dict for metric options. Options are
                 ``max_avg_proposals``, ``temporal_iou_thresholds`` for
                 ``AR@AN``.
+                default: ``{'AR@AN': dict(max_avg_proposals=100,
+                temporal_iou_thresholds=np.linspace(0.5, 0.95, 10))}``.
             logger (logging.Logger | None): Training logger. Defaults: None.
 
         Returns:

--- a/mmaction/datasets/activitynet_dataset.py
+++ b/mmaction/datasets/activitynet_dataset.py
@@ -201,7 +201,7 @@ class ActivityNetDataset(BaseDataset):
         Returns:
             dict: Evaluation results for evaluation metrics.
         """
-        # Protect ``metric_dict`` since it use immutable value as default
+        # Protect ``metric_dict`` since it uses mutable value as default
         metric_dict = copy.deepcopy(metric_dict)
 
         if not isinstance(results, list):

--- a/mmaction/datasets/activitynet_dataset.py
+++ b/mmaction/datasets/activitynet_dataset.py
@@ -185,8 +185,9 @@ class ActivityNetDataset(BaseDataset):
     def evaluate(self,
                  results,
                  metrics='AR@AN',
-                 max_avg_proposals=100,
-                 temporal_iou_thresholds=np.linspace(0.5, 0.95, 10),
+                 metric_dict=dict(
+                     max_avg_proposals=100,
+                     temporal_iou_thresholds=np.linspace(0.5, 0.95, 10)),
                  logger=None):
         """Evaluation in feature dataset.
 
@@ -194,10 +195,7 @@ class ActivityNetDataset(BaseDataset):
             results (list[dict]): Output results.
             metrics (str | sequence[str]): Metrics to be performed.
                 Defaults: 'AR@AN'.
-            max_avg_proposals (int): Max number of proposals to evaluate.
-                Defaults: 100.
-            temporal_iou_thresholds (list | np.ndarray): Temporal IoU threshold
-                for positive samples. Defaults: np.linspace(0.5, 0.95, 10).
+            metric_dict (dict): Dict for metric options.
             logger (logging.Logger | None): Training logger. Defaults: None.
 
         Returns:
@@ -215,15 +213,18 @@ class ActivityNetDataset(BaseDataset):
             if metric not in allowed_metrics:
                 raise KeyError(f'metric {metric} is not supported')
 
-        if isinstance(temporal_iou_thresholds, list):
-            temporal_iou_thresholds = np.array(temporal_iou_thresholds)
-
         eval_results = {}
         ground_truth = self._import_ground_truth()
         proposal, num_proposals = self._import_proposals(results)
 
         for metric in metrics:
             if metric == 'AR@AN':
+                temporal_iou_thresholds = metric_dict.get(
+                    'temporal_iou_thresholds')
+                max_avg_proposals = metric_dict.get('max_avg_proposals')
+                if isinstance(temporal_iou_thresholds, list):
+                    temporal_iou_thresholds = np.array(temporal_iou_thresholds)
+
                 recall, _, _, auc = (
                     average_recall_at_avg_proposals(
                         ground_truth,

--- a/mmaction/datasets/audio_dataset.py
+++ b/mmaction/datasets/audio_dataset.py
@@ -1,9 +1,7 @@
 import os.path as osp
 
 import torch
-from mmcv.utils import print_log
 
-from ..core import mean_class_accuracy, top_k_accuracy
 from .base import BaseDataset
 from .registry import DATASETS
 
@@ -69,67 +67,3 @@ class AudioDataset(BaseDataset):
                 video_infos.append(video_info)
 
         return video_infos
-
-    def evaluate(self,
-                 results,
-                 metrics='top_k_accuracy',
-                 topk=(1, 5),
-                 logger=None):
-        """Evaluation in audio dataset.
-
-        Args:
-            results (list): Output results.
-            metrics (str | sequence[str]): Metrics to be performed.
-                Defaults: 'top_k_accuracy'.
-            logger (obj): Training logger. Defaults: None.
-            topk (tuple[int]): K value for top_k_accuracy metric.
-                Defaults: (1, 5).
-            logger (logging.Logger | None): Logger for recording.
-                Default: None.
-
-        Returns:
-            dict: Evaluation results dict.
-        """
-        if not isinstance(results, list):
-            raise TypeError(f'results must be a list, but got {type(results)}')
-        assert len(results) == len(self), (
-            f'The length of results is not equal to the dataset len: '
-            f'{len(results)} != {len(self)}')
-
-        if not isinstance(topk, (int, tuple)):
-            raise TypeError(
-                f'topk must be int or tuple of int, but got {type(topk)}')
-
-        metrics = metrics if isinstance(metrics, (list, tuple)) else [metrics]
-        allowed_metrics = ['top_k_accuracy', 'mean_class_accuracy']
-        for metric in metrics:
-            if metric not in allowed_metrics:
-                raise KeyError(f'metric {metric} is not supported')
-
-        eval_results = {}
-        gt_labels = [ann['label'] for ann in self.video_infos]
-
-        for metric in metrics:
-            msg = f'Evaluating {metric}...'
-            if logger is None:
-                msg = '\n' + msg
-            print_log(msg, logger=logger)
-
-            if metric == 'top_k_accuracy':
-                top_k_acc = top_k_accuracy(results, gt_labels, topk)
-                log_msg = []
-                for k, acc in zip(topk, top_k_acc):
-                    eval_results[f'top{k}_acc'] = acc
-                    log_msg.append(f'\ntop{k}_acc\t{acc:.4f}')
-                log_msg = ''.join(log_msg)
-                print_log(log_msg, logger=logger)
-                continue
-
-            if metric == 'mean_class_accuracy':
-                mean_acc = mean_class_accuracy(results, gt_labels)
-                eval_results['mean_class_accuracy'] = mean_acc
-                log_msg = f'\nmean_acc\t{mean_acc:.4f}'
-                print_log(log_msg, logger=logger)
-                continue
-
-        return eval_results

--- a/mmaction/datasets/audio_feature_dataset.py
+++ b/mmaction/datasets/audio_feature_dataset.py
@@ -1,9 +1,7 @@
 import os.path as osp
 
 import torch
-from mmcv.utils import print_log
 
-from ..core import mean_class_accuracy, top_k_accuracy
 from .base import BaseDataset
 from .registry import DATASETS
 
@@ -70,67 +68,3 @@ class AudioFeatureDataset(BaseDataset):
                 video_infos.append(video_info)
 
         return video_infos
-
-    def evaluate(self,
-                 results,
-                 metrics='top_k_accuracy',
-                 topk=(1, 5),
-                 logger=None):
-        """Evaluation in audio feature dataset.
-
-        Args:
-            results (list): Output results.
-            metrics (str | sequence[str]): Metrics to be performed.
-                Defaults: 'top_k_accuracy'.
-            logger (obj): Training logger. Defaults: None.
-            topk (tuple[int]): K value for top_k_accuracy metric.
-                Defaults: (1, 5).
-            logger (logging.Logger | None): Logger for recording.
-                Default: None.
-
-        Returns:
-            dict: Evaluation results dict.
-        """
-        if not isinstance(results, list):
-            raise TypeError(f'results must be a list, but got {type(results)}')
-        assert len(results) == len(self), (
-            f'The length of results is not equal to the dataset len: '
-            f'{len(results)} != {len(self)}')
-
-        if not isinstance(topk, (int, tuple)):
-            raise TypeError(
-                f'topk must be int or tuple of int, but got {type(topk)}')
-
-        metrics = metrics if isinstance(metrics, (list, tuple)) else [metrics]
-        allowed_metrics = ['top_k_accuracy', 'mean_class_accuracy']
-        for metric in metrics:
-            if metric not in allowed_metrics:
-                raise KeyError(f'metric {metric} is not supported')
-
-        eval_results = {}
-        gt_labels = [ann['label'] for ann in self.video_infos]
-
-        for metric in metrics:
-            msg = f'Evaluating {metric}...'
-            if logger is None:
-                msg = '\n' + msg
-            print_log(msg, logger=logger)
-
-            if metric == 'top_k_accuracy':
-                top_k_acc = top_k_accuracy(results, gt_labels, topk)
-                log_msg = []
-                for k, acc in zip(topk, top_k_acc):
-                    eval_results[f'top{k}_acc'] = acc
-                    log_msg.append(f'\ntop{k}_acc\t{acc:.4f}')
-                log_msg = ''.join(log_msg)
-                print_log(log_msg, logger=logger)
-                continue
-
-            if metric == 'mean_class_accuracy':
-                mean_acc = mean_class_accuracy(results, gt_labels)
-                eval_results['mean_class_accuracy'] = mean_acc
-                log_msg = f'\nmean_acc\t{mean_acc:.4f}'
-                print_log(log_msg, logger=logger)
-                continue
-
-        return eval_results

--- a/mmaction/datasets/ava_dataset.py
+++ b/mmaction/datasets/ava_dataset.py
@@ -240,5 +240,5 @@ class AVADataset(BaseDataset):
         results['proposals'] = self.proposals[img_key][:self.num_max_proposals]
         return self.pipeline(results)
 
-    def evaluate(self, results, metrics, metric_dict, logger):
+    def evaluate(self, results, metrics, metric_options, logger):
         raise NotImplementedError

--- a/mmaction/datasets/ava_dataset.py
+++ b/mmaction/datasets/ava_dataset.py
@@ -240,5 +240,5 @@ class AVADataset(BaseDataset):
         results['proposals'] = self.proposals[img_key][:self.num_max_proposals]
         return self.pipeline(results)
 
-    def evaluate(self, results, metrics, logger):
+    def evaluate(self, results, metrics, metric_dict, logger):
         raise NotImplementedError

--- a/mmaction/datasets/base.py
+++ b/mmaction/datasets/base.py
@@ -129,7 +129,7 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
             logger (logging.Logger | None): Logger for recording.
                 Default: None.
 
-        Return:
+        Returns:
             dict: Evaluation results dict.
         """
         # Protect ``metric_dict`` since it use immutable value as default

--- a/mmaction/datasets/base.py
+++ b/mmaction/datasets/base.py
@@ -123,7 +123,6 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
             results (list): Output results.
             metrics (str | sequence[str]): Metrics to be performed.
                 Defaults: 'top_k_accuracy'.
-            logger (obj): Training logger. Defaults: None.
             metric_dict (dict): Dict for metric options.
                 Default: ``dict(topk=(1, 5))``.
             logger (logging.Logger | None): Logger for recording.
@@ -132,7 +131,7 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
         Returns:
             dict: Evaluation results dict.
         """
-        # Protect ``metric_dict`` since it use immutable value as default
+        # Protect ``metric_dict`` since it uses immutable value as default
         metric_dict = copy.deepcopy(metric_dict)
 
         if not isinstance(results, list):

--- a/mmaction/datasets/base.py
+++ b/mmaction/datasets/base.py
@@ -138,7 +138,7 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
         Returns:
             dict: Evaluation results dict.
         """
-        # Protect ``metric_dict`` since it uses immutable value as default
+        # Protect ``metric_dict`` since it uses mutable value as default
         metric_dict = copy.deepcopy(metric_dict)
 
         if not isinstance(results, list):

--- a/mmaction/datasets/base.py
+++ b/mmaction/datasets/base.py
@@ -122,7 +122,7 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
     def evaluate(self,
                  results,
                  metrics='top_k_accuracy',
-                 metric_dict=dict(topk=(1, 5)),
+                 metric_options=dict(top_k_accuracy=dict(topk=(1, 5))),
                  logger=None):
         """Perform evaluation for common datasets.
 
@@ -130,16 +130,16 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
             results (list): Output results.
             metrics (str | sequence[str]): Metrics to be performed.
                 Defaults: 'top_k_accuracy'.
-            metric_dict (dict): Dict for metric options.
-                Default: ``dict(topk=(1, 5))``.
+            metric_options (dict): Dict for metric options.
+                Default: ``dict(top_k_accuracy=dict(topk=(1, 5)))``.
             logger (logging.Logger | None): Logger for recording.
                 Default: None.
 
         Returns:
             dict: Evaluation results dict.
         """
-        # Protect ``metric_dict`` since it uses mutable value as default
-        metric_dict = copy.deepcopy(metric_dict)
+        # Protect ``metric_options`` since it uses mutable value as default
+        metric_options = copy.deepcopy(metric_options)
 
         if not isinstance(results, list):
             raise TypeError(f'results must be a list, but got {type(results)}')
@@ -167,7 +167,7 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
             print_log(msg, logger=logger)
 
             if metric == 'top_k_accuracy':
-                topk = metric_dict.get('topk')
+                topk = metric_options['top_k_accuracy'].get('topk')
                 if not isinstance(topk, (int, tuple)):
                     raise TypeError('topk must be int or tuple of int, '
                                     f'but got {type(topk)}')

--- a/mmaction/datasets/base.py
+++ b/mmaction/datasets/base.py
@@ -1,5 +1,6 @@
 import copy
 import os.path as osp
+import warnings
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 
@@ -123,7 +124,8 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
                  results,
                  metrics='top_k_accuracy',
                  metric_options=dict(top_k_accuracy=dict(topk=(1, 5))),
-                 logger=None):
+                 logger=None,
+                 **deprecated_kwargs):
         """Perform evaluation for common datasets.
 
         Args:
@@ -135,12 +137,22 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
                 Default: ``dict(top_k_accuracy=dict(topk=(1, 5)))``.
             logger (logging.Logger | None): Logger for recording.
                 Default: None.
+            deprecated_kwargs (dict): Used for containing deprecated arguments.
+                See 'https://github.com/open-mmlab/mmaction2/pull/286'.
 
         Returns:
             dict: Evaluation results dict.
         """
         # Protect ``metric_options`` since it uses mutable value as default
         metric_options = copy.deepcopy(metric_options)
+
+        if deprecated_kwargs != {}:
+            warnings.warn(
+                'Option arguments for metrics has been changed to '
+                "`metric_options`, See 'https://github.com/open-mmlab/mmaction2/pull/286' "  # noqa: E501
+                'for more details')
+            metric_options['top_k_accuracy'] = dict(
+                metric_options['top_k_accuracy'], **deprecated_kwargs)
 
         if not isinstance(results, list):
             raise TypeError(f'results must be a list, but got {type(results)}')

--- a/mmaction/datasets/base.py
+++ b/mmaction/datasets/base.py
@@ -130,7 +130,8 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
             results (list): Output results.
             metrics (str | sequence[str]): Metrics to be performed.
                 Defaults: 'top_k_accuracy'.
-            metric_options (dict): Dict for metric options.
+            metric_options (dict): Dict for metric options. Options are
+                ``topk`` for ``top_k_accuracy``.
                 Default: ``dict(top_k_accuracy=dict(topk=(1, 5)))``.
             logger (logging.Logger | None): Logger for recording.
                 Default: None.
@@ -167,7 +168,9 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
             print_log(msg, logger=logger)
 
             if metric == 'top_k_accuracy':
-                topk = metric_options['top_k_accuracy'].get('topk')
+                topk = metric_options.setdefault('top_k_accuracy',
+                                                 {}).setdefault(
+                                                     'topk', (1, 5))
                 if not isinstance(topk, (int, tuple)):
                     raise TypeError('topk must be int or tuple of int, '
                                     f'but got {type(topk)}')

--- a/mmaction/datasets/hvu_dataset.py
+++ b/mmaction/datasets/hvu_dataset.py
@@ -144,7 +144,7 @@ class HVUDataset(BaseDataset):
         Returns:
             dict: Evaluation results dict.
         """
-        # Protect ``metric_dict`` since it uses immutable value as default
+        # Protect ``metric_dict`` since it uses mutable value as default
         metric_dict = copy.deepcopy(metric_dict)
 
         if not isinstance(results, list):

--- a/mmaction/datasets/hvu_dataset.py
+++ b/mmaction/datasets/hvu_dataset.py
@@ -123,7 +123,11 @@ class HVUDataset(BaseDataset):
         arr[label] = 1.
         return arr
 
-    def evaluate(self, results, metrics='mean_average_precision', logger=None):
+    def evaluate(self,
+                 results,
+                 metrics='mean_average_precision',
+                 metric_dict=None,
+                 logger=None):
         """Evaluation in HVU Video Dataset. We only support evaluating mAP for
         each tag categories. Since some tag categories are missing for some
         videos, we can not evaluate mAP for all tags.
@@ -132,6 +136,7 @@ class HVUDataset(BaseDataset):
             results (list): Output results.
             metrics (str | sequence[str]): Metrics to be performed.
                 Defaults: 'mean_average_precision'.
+            metric_dict (dict | None): Dict for metric options. Default: None.
             logger (logging.Logger | None): Logger for recording.
                 Default: None.
 

--- a/mmaction/datasets/hvu_dataset.py
+++ b/mmaction/datasets/hvu_dataset.py
@@ -1,3 +1,4 @@
+import copy
 import os.path as osp
 
 import mmcv
@@ -143,6 +144,9 @@ class HVUDataset(BaseDataset):
         Returns:
             dict: Evaluation results dict.
         """
+        # Protect ``metric_dict`` since it uses immutable value as default
+        metric_dict = copy.deepcopy(metric_dict)
+
         if not isinstance(results, list):
             raise TypeError(f'results must be a list, but got {type(results)}')
         assert len(results) == len(self), (

--- a/mmaction/datasets/hvu_dataset.py
+++ b/mmaction/datasets/hvu_dataset.py
@@ -127,7 +127,7 @@ class HVUDataset(BaseDataset):
     def evaluate(self,
                  results,
                  metrics='mean_average_precision',
-                 metric_dict=None,
+                 metric_options=None,
                  logger=None):
         """Evaluation in HVU Video Dataset. We only support evaluating mAP for
         each tag categories. Since some tag categories are missing for some
@@ -137,15 +137,16 @@ class HVUDataset(BaseDataset):
             results (list): Output results.
             metrics (str | sequence[str]): Metrics to be performed.
                 Defaults: 'mean_average_precision'.
-            metric_dict (dict | None): Dict for metric options. Default: None.
+            metric_options (dict | None): Dict for metric options.
+                Default: None.
             logger (logging.Logger | None): Logger for recording.
                 Default: None.
 
         Returns:
             dict: Evaluation results dict.
         """
-        # Protect ``metric_dict`` since it uses mutable value as default
-        metric_dict = copy.deepcopy(metric_dict)
+        # Protect ``metric_options`` since it uses mutable value as default
+        metric_options = copy.deepcopy(metric_options)
 
         if not isinstance(results, list):
             raise TypeError(f'results must be a list, but got {type(results)}')

--- a/mmaction/datasets/image_dataset.py
+++ b/mmaction/datasets/image_dataset.py
@@ -41,4 +41,4 @@ class ImageDataset(VideoDataset):
     """
 
     def __init__(self, ann_file, pipeline, **kwargs):
-        super().__init__(ann_file, pipeline, start_index=None, **kwargs)
+        super().__init__(ann_file, pipeline, **kwargs)

--- a/mmaction/datasets/image_dataset.py
+++ b/mmaction/datasets/image_dataset.py
@@ -41,4 +41,5 @@ class ImageDataset(VideoDataset):
     """
 
     def __init__(self, ann_file, pipeline, **kwargs):
-        super().__init__(ann_file, pipeline, **kwargs)
+        super().__init__(ann_file, pipeline, start_index=None, **kwargs)
+        # use `start_index=None` to indicate it is for `ImageDataset`

--- a/mmaction/datasets/rawframe_dataset.py
+++ b/mmaction/datasets/rawframe_dataset.py
@@ -201,7 +201,7 @@ class RawframeDataset(BaseDataset):
     def evaluate(self,
                  results,
                  metrics='top_k_accuracy',
-                 topk=(1, 5),
+                 metric_dict=dict(topk=(1, 5)),
                  logger=None):
         """Evaluation in rawframe dataset.
 
@@ -210,8 +210,8 @@ class RawframeDataset(BaseDataset):
             metrics (str | sequence[str]): Metrics to be performed.
                 Defaults: 'top_k_accuracy'.
             logger (obj): Training logger. Defaults: None.
-            topk (int | tuple[int]): K value for top_k_accuracy metric.
-                Defaults: (1, 5).
+            metric_dict (dict): Dict for metric options.
+                Default: ``dict(topk=(1, 5))``.
             logger (logging.Logger | None): Logger for recording.
                 Default: None.
 
@@ -224,13 +224,6 @@ class RawframeDataset(BaseDataset):
         assert len(results) == len(self), (
             f'The length of results is not equal to the dataset len: '
             f'{len(results)} != {len(self)}')
-
-        if not isinstance(topk, (int, tuple)):
-            raise TypeError(
-                f'topk must be int or tuple of int, but got {type(topk)}')
-
-        if isinstance(topk, int):
-            topk = (topk, )
 
         metrics = metrics if isinstance(metrics, (list, tuple)) else [metrics]
         allowed_metrics = [
@@ -250,6 +243,13 @@ class RawframeDataset(BaseDataset):
             print_log(msg, logger=logger)
 
             if metric == 'top_k_accuracy':
+                topk = metric_dict.get('topk')
+                if not isinstance(topk, (int, tuple)):
+                    raise TypeError('topk must be int or tuple of int, '
+                                    f'but got {type(topk)}')
+                if isinstance(topk, int):
+                    topk = (topk, )
+
                 top_k_acc = top_k_accuracy(results, gt_labels, topk)
                 log_msg = []
                 for k, acc in zip(topk, top_k_acc):

--- a/mmaction/datasets/rawframe_dataset.py
+++ b/mmaction/datasets/rawframe_dataset.py
@@ -192,12 +192,6 @@ class RawframeDataset(BaseDataset):
 
         return self.pipeline(results)
 
-    @staticmethod
-    def label2array(num, label):
-        arr = np.zeros(num, dtype=np.float32)
-        arr[label] = 1.
-        return arr
-
     def evaluate(self,
                  results,
                  metrics='top_k_accuracy',
@@ -238,7 +232,7 @@ class RawframeDataset(BaseDataset):
         gt_labels = [ann['label'] for ann in self.video_infos]
 
         for metric in metrics:
-            msg = f'Evaluating {metric}...'
+            msg = f'Evaluating {metric} ...'
             if logger is None:
                 msg = '\n' + msg
             print_log(msg, logger=logger)

--- a/mmaction/datasets/rawframe_dataset.py
+++ b/mmaction/datasets/rawframe_dataset.py
@@ -209,7 +209,6 @@ class RawframeDataset(BaseDataset):
             results (list): Output results.
             metrics (str | sequence[str]): Metrics to be performed.
                 Defaults: 'top_k_accuracy'.
-            logger (obj): Training logger. Defaults: None.
             metric_dict (dict): Dict for metric options.
                 Default: ``dict(topk=(1, 5))``.
             logger (logging.Logger | None): Logger for recording.
@@ -218,6 +217,8 @@ class RawframeDataset(BaseDataset):
         Returns:
             dict: Evaluation results dict.
         """
+        # Protect ``metric_dict`` since it uses immutable value as default
+        metric_dict = copy.deepcopy(metric_dict)
 
         if not isinstance(results, list):
             raise TypeError(f'results must be a list, but got {type(results)}')

--- a/mmaction/datasets/rawframe_dataset.py
+++ b/mmaction/datasets/rawframe_dataset.py
@@ -3,10 +3,7 @@ import os.path as osp
 
 import numpy as np
 import torch
-from mmcv.utils import print_log
 
-from ..core import (mean_average_precision, mean_class_accuracy,
-                    mmit_mean_average_precision, top_k_accuracy)
 from .base import BaseDataset
 from .registry import DATASETS
 
@@ -191,90 +188,3 @@ class RawframeDataset(BaseDataset):
             results['label'] = onehot
 
         return self.pipeline(results)
-
-    def evaluate(self,
-                 results,
-                 metrics='top_k_accuracy',
-                 metric_dict=dict(topk=(1, 5)),
-                 logger=None):
-        """Evaluation in rawframe dataset.
-
-        Args:
-            results (list): Output results.
-            metrics (str | sequence[str]): Metrics to be performed.
-                Defaults: 'top_k_accuracy'.
-            metric_dict (dict): Dict for metric options.
-                Default: ``dict(topk=(1, 5))``.
-            logger (logging.Logger | None): Logger for recording.
-                Default: None.
-
-        Returns:
-            dict: Evaluation results dict.
-        """
-        # Protect ``metric_dict`` since it uses immutable value as default
-        metric_dict = copy.deepcopy(metric_dict)
-
-        if not isinstance(results, list):
-            raise TypeError(f'results must be a list, but got {type(results)}')
-        assert len(results) == len(self), (
-            f'The length of results is not equal to the dataset len: '
-            f'{len(results)} != {len(self)}')
-
-        metrics = metrics if isinstance(metrics, (list, tuple)) else [metrics]
-        allowed_metrics = [
-            'top_k_accuracy', 'mean_class_accuracy', 'mean_average_precision'
-        ]
-        for metric in metrics:
-            if metric not in allowed_metrics:
-                raise KeyError(f'metric {metric} is not supported')
-
-        eval_results = {}
-        gt_labels = [ann['label'] for ann in self.video_infos]
-
-        for metric in metrics:
-            msg = f'Evaluating {metric} ...'
-            if logger is None:
-                msg = '\n' + msg
-            print_log(msg, logger=logger)
-
-            if metric == 'top_k_accuracy':
-                topk = metric_dict.get('topk')
-                if not isinstance(topk, (int, tuple)):
-                    raise TypeError('topk must be int or tuple of int, '
-                                    f'but got {type(topk)}')
-                if isinstance(topk, int):
-                    topk = (topk, )
-
-                top_k_acc = top_k_accuracy(results, gt_labels, topk)
-                log_msg = []
-                for k, acc in zip(topk, top_k_acc):
-                    eval_results[f'top{k}_acc'] = acc
-                    log_msg.append(f'\ntop{k}_acc\t{acc:.4f}')
-                log_msg = ''.join(log_msg)
-                print_log(log_msg, logger=logger)
-                continue
-
-            if metric == 'mean_class_accuracy':
-                mean_acc = mean_class_accuracy(results, gt_labels)
-                eval_results['mean_class_accuracy'] = mean_acc
-                log_msg = f'\nmean_acc\t{mean_acc:.4f}'
-                print_log(log_msg, logger=logger)
-                continue
-
-            if metric in [
-                    'mean_average_precision', 'mmit_mean_average_precision'
-            ]:
-                gt_labels = [
-                    self.label2array(self.num_classes, label)
-                    for label in gt_labels
-                ]
-                if metric == 'mean_average_precision':
-                    mAP = mean_average_precision(results, gt_labels)
-                elif metric == 'mmit_mean_average_precision':
-                    mAP = mmit_mean_average_precision(results, gt_labels)
-                eval_results['mean_average_precision'] = mAP
-                log_msg = f'\nmean_average_precision\t{mAP:.4f}'
-                print_log(log_msg, logger=logger)
-                continue
-
-        return eval_results

--- a/mmaction/datasets/rawvideo_dataset.py
+++ b/mmaction/datasets/rawvideo_dataset.py
@@ -147,12 +147,13 @@ class RawVideoDataset(BaseDataset):
 
     # Since the dataset is only used for joint training, we do not implement
     # the evaluate function.
-    def evaluate(self, results, metrics, logger):
+    def evaluate(self, results, metrics, metric_dict, logger):
         """Evaluation for the dataset.
 
         Args:
             results (list): Output results.
             metrics (str | sequence[str]): Metrics to be performed.
+            metric_dict (dict): Dict for metric options.
             logger (logging.Logger | None): Logger for recording.
 
         Returns:

--- a/mmaction/datasets/rawvideo_dataset.py
+++ b/mmaction/datasets/rawvideo_dataset.py
@@ -147,13 +147,13 @@ class RawVideoDataset(BaseDataset):
 
     # Since the dataset is only used for joint training, we do not implement
     # the evaluate function.
-    def evaluate(self, results, metrics, metric_dict, logger):
+    def evaluate(self, results, metrics, metric_options, logger):
         """Evaluation for the dataset.
 
         Args:
             results (list): Output results.
             metrics (str | sequence[str]): Metrics to be performed.
-            metric_dict (dict): Dict for metric options.
+            metric_options (dict): Dict for metric options.
             logger (logging.Logger | None): Logger for recording.
 
         Returns:

--- a/mmaction/datasets/ssn_dataset.py
+++ b/mmaction/datasets/ssn_dataset.py
@@ -401,15 +401,17 @@ class SSNDataset(BaseDataset):
     def evaluate(self,
                  results,
                  metrics='mAP',
-                 eval_dataset='thumos14',
-                 **kwargs):
+                 metric_dict=dict(eval_dataset='thumos14'),
+                 logger=None):
         """Evaluation in SSN proposal dataset.
 
         Args:
             results (list[dict]): Output results.
             metrics (str | sequence[str]): Metrics to be performed.
                 Defaults: 'mAP'.
-            eval_dataset (str): Dataset to be evaluated.
+            metric_dict (dict): Dict for metric options.
+            logger (logging.Logger | None): Logger for recording.
+                Default: None.
 
         Returns:
             dict: Evaluation results for evaluation metrics.
@@ -463,6 +465,7 @@ class SSNDataset(BaseDataset):
         eval_results = {}
         for metric in metrics:
             if metric == 'mAP':
+                eval_dataset = metric_dict.get('eval_dataset')
                 if eval_dataset == 'thumos14':
                     iou_range = np.arange(0.1, 1.0, .1)
                     ap_values = eval_ap(plain_detections, all_gts, iou_range)

--- a/mmaction/datasets/ssn_dataset.py
+++ b/mmaction/datasets/ssn_dataset.py
@@ -416,7 +416,7 @@ class SSNDataset(BaseDataset):
         Returns:
             dict: Evaluation results for evaluation metrics.
         """
-        # Protect ``metric_dict`` since it uses immutable value as default
+        # Protect ``metric_dict`` since it uses mutable value as default
         metric_dict = copy.deepcopy(metric_dict)
 
         if not isinstance(results, list):

--- a/mmaction/datasets/ssn_dataset.py
+++ b/mmaction/datasets/ssn_dataset.py
@@ -409,7 +409,8 @@ class SSNDataset(BaseDataset):
             results (list[dict]): Output results.
             metrics (str | sequence[str]): Metrics to be performed.
                 Defaults: 'mAP'.
-            metric_options (dict): Dict for metric options.
+            metric_options (dict): Dict for metric options. Options are
+                ``eval_dataset`` for ``mAP``.
             logger (logging.Logger | None): Logger for recording.
                 Default: None.
 
@@ -468,7 +469,8 @@ class SSNDataset(BaseDataset):
         eval_results = {}
         for metric in metrics:
             if metric == 'mAP':
-                eval_dataset = metric_options['mAP'].get('eval_dataset')
+                eval_dataset = metric_options.setdefault('mAP', {}).setdefault(
+                    'eval_dataset', 'thumos14')
                 if eval_dataset == 'thumos14':
                     iou_range = np.arange(0.1, 1.0, .1)
                     ap_values = eval_ap(plain_detections, all_gts, iou_range)

--- a/mmaction/datasets/ssn_dataset.py
+++ b/mmaction/datasets/ssn_dataset.py
@@ -416,6 +416,9 @@ class SSNDataset(BaseDataset):
         Returns:
             dict: Evaluation results for evaluation metrics.
         """
+        # Protect ``metric_dict`` since it uses immutable value as default
+        metric_dict = copy.deepcopy(metric_dict)
+
         if not isinstance(results, list):
             raise TypeError(f'results must be a list, but got {type(results)}')
         assert len(results) == len(self), (

--- a/mmaction/datasets/ssn_dataset.py
+++ b/mmaction/datasets/ssn_dataset.py
@@ -411,6 +411,7 @@ class SSNDataset(BaseDataset):
                 Defaults: 'mAP'.
             metric_options (dict): Dict for metric options. Options are
                 ``eval_dataset`` for ``mAP``.
+                Default: ``dict(mAP=dict(eval_dataset='thumos14'))``.
             logger (logging.Logger | None): Logger for recording.
                 Default: None.
 

--- a/mmaction/datasets/ssn_dataset.py
+++ b/mmaction/datasets/ssn_dataset.py
@@ -401,7 +401,7 @@ class SSNDataset(BaseDataset):
     def evaluate(self,
                  results,
                  metrics='mAP',
-                 metric_dict=dict(eval_dataset='thumos14'),
+                 metric_options=dict(mAP=dict(eval_dataset='thumos14')),
                  logger=None):
         """Evaluation in SSN proposal dataset.
 
@@ -409,15 +409,15 @@ class SSNDataset(BaseDataset):
             results (list[dict]): Output results.
             metrics (str | sequence[str]): Metrics to be performed.
                 Defaults: 'mAP'.
-            metric_dict (dict): Dict for metric options.
+            metric_options (dict): Dict for metric options.
             logger (logging.Logger | None): Logger for recording.
                 Default: None.
 
         Returns:
             dict: Evaluation results for evaluation metrics.
         """
-        # Protect ``metric_dict`` since it uses mutable value as default
-        metric_dict = copy.deepcopy(metric_dict)
+        # Protect ``metric_options`` since it uses mutable value as default
+        metric_options = copy.deepcopy(metric_options)
 
         if not isinstance(results, list):
             raise TypeError(f'results must be a list, but got {type(results)}')
@@ -468,7 +468,7 @@ class SSNDataset(BaseDataset):
         eval_results = {}
         for metric in metrics:
             if metric == 'mAP':
-                eval_dataset = metric_dict.get('eval_dataset')
+                eval_dataset = metric_options['mAP'].get('eval_dataset')
                 if eval_dataset == 'thumos14':
                     iou_range = np.arange(0.1, 1.0, .1)
                     ap_values = eval_ap(plain_detections, all_gts, iou_range)

--- a/mmaction/datasets/ssn_dataset.py
+++ b/mmaction/datasets/ssn_dataset.py
@@ -1,5 +1,6 @@
 import copy
 import os.path as osp
+import warnings
 
 import mmcv
 import numpy as np
@@ -402,7 +403,8 @@ class SSNDataset(BaseDataset):
                  results,
                  metrics='mAP',
                  metric_options=dict(mAP=dict(eval_dataset='thumos14')),
-                 logger=None):
+                 logger=None,
+                 **deprecated_kwargs):
         """Evaluation in SSN proposal dataset.
 
         Args:
@@ -414,12 +416,22 @@ class SSNDataset(BaseDataset):
                 Default: ``dict(mAP=dict(eval_dataset='thumos14'))``.
             logger (logging.Logger | None): Logger for recording.
                 Default: None.
+            deprecated_kwargs (dict): Used for containing deprecated arguments.
+                See 'https://github.com/open-mmlab/mmaction2/pull/286'.
 
         Returns:
             dict: Evaluation results for evaluation metrics.
         """
         # Protect ``metric_options`` since it uses mutable value as default
         metric_options = copy.deepcopy(metric_options)
+
+        if deprecated_kwargs != {}:
+            warnings.warn(
+                'Option arguments for metrics has been changed to '
+                "`metric_options`, See 'https://github.com/open-mmlab/mmaction2/pull/286' "  # noqa: E501
+                'for more details')
+            metric_options['mAP'] = dict(metric_options['mAP'],
+                                         **deprecated_kwargs)
 
         if not isinstance(results, list):
             raise TypeError(f'results must be a list, but got {type(results)}')

--- a/mmaction/datasets/video_dataset.py
+++ b/mmaction/datasets/video_dataset.py
@@ -1,9 +1,7 @@
 import os.path as osp
 
 import torch
-from mmcv.utils import print_log
 
-from ..core import mean_class_accuracy, top_k_accuracy
 from .base import BaseDataset
 from .registry import DATASETS
 
@@ -67,67 +65,3 @@ class VideoDataset(BaseDataset):
                         filename=filename,
                         label=onehot if self.multi_class else label))
         return video_infos
-
-    def evaluate(self,
-                 results,
-                 metrics='top_k_accuracy',
-                 topk=(1, 5),
-                 logger=None):
-        """Evaluation in video dataset.
-
-        Args:
-            results (list): Output results.
-            metrics (str | sequence[str]): Metrics to be performed.
-                Defaults: 'top_k_accuracy'.
-            logger (obj): Training logger. Defaults: None.
-            topk (tuple[int]): K value for top_k_accuracy metric.
-                Defaults: (1, 5).
-            logger (logging.Logger | None): Logger for recording.
-                Default: None.
-
-        Returns:
-            dict: Evaluation results dict.
-        """
-        if not isinstance(results, list):
-            raise TypeError(f'results must be a list, but got {type(results)}')
-        assert len(results) == len(self), (
-            f'The length of results is not equal to the dataset len: '
-            f'{len(results)} != {len(self)}')
-
-        if not isinstance(topk, (int, tuple)):
-            raise TypeError(
-                f'topk must be int or tuple of int, but got {type(topk)}')
-
-        metrics = metrics if isinstance(metrics, (list, tuple)) else [metrics]
-        allowed_metrics = ['top_k_accuracy', 'mean_class_accuracy']
-        for metric in metrics:
-            if metric not in allowed_metrics:
-                raise KeyError(f'metric {metric} is not supported')
-
-        eval_results = {}
-        gt_labels = [ann['label'] for ann in self.video_infos]
-
-        for metric in metrics:
-            msg = f'Evaluating {metric}...'
-            if logger is None:
-                msg = '\n' + msg
-            print_log(msg, logger=logger)
-
-            if metric == 'top_k_accuracy':
-                top_k_acc = top_k_accuracy(results, gt_labels, topk)
-                log_msg = []
-                for k, acc in zip(topk, top_k_acc):
-                    eval_results[f'top{k}_acc'] = acc
-                    log_msg.append(f'\ntop{k}_acc\t{acc:.4f}')
-                log_msg = ''.join(log_msg)
-                print_log(log_msg, logger=logger)
-                continue
-
-            if metric == 'mean_class_accuracy':
-                mean_acc = mean_class_accuracy(results, gt_labels)
-                eval_results['mean_class_accuracy'] = mean_acc
-                log_msg = f'\nmean_acc\t{mean_acc:.4f}'
-                print_log(log_msg, logger=logger)
-                continue
-
-        return eval_results

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -495,7 +495,8 @@ class TestDataset:
 
         with pytest.raises(TypeError):
             # topk must be int or tuple of int
-            rawframe_dataset.evaluate([0] * len(rawframe_dataset), topk=1.0)
+            rawframe_dataset.evaluate(
+                [0] * len(rawframe_dataset), metric_dict=dict(topk=1.0))
 
         with pytest.raises(KeyError):
             # unsupported metric
@@ -525,7 +526,8 @@ class TestDataset:
 
         with pytest.raises(TypeError):
             # topk must be int or tuple of int
-            video_dataset.evaluate([0] * len(video_dataset), topk=1.0)
+            video_dataset.evaluate(
+                [0] * len(video_dataset), metric_dict=dict(topk=1.0))
 
         with pytest.raises(KeyError):
             # unsupported metric
@@ -840,7 +842,8 @@ class TestDataset:
 
         with pytest.raises(TypeError):
             # topk must be int or tuple of int
-            audio_dataset.evaluate([0] * len(audio_dataset), topk=1.0)
+            audio_dataset.evaluate(
+                [0] * len(audio_dataset), metric_dict=dict(topk=1.0))
 
         with pytest.raises(KeyError):
             # unsupported metric
@@ -869,7 +872,8 @@ class TestDataset:
 
         with pytest.raises(TypeError):
             # topk must be int or tuple of int
-            audio_dataset.evaluate([0] * len(audio_dataset), topk=1.0)
+            audio_dataset.evaluate(
+                [0] * len(audio_dataset), metric_dict=dict(topk=1.0))
 
         with pytest.raises(KeyError):
             # unsupported metric

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -496,7 +496,8 @@ class TestDataset:
         with pytest.raises(TypeError):
             # topk must be int or tuple of int
             rawframe_dataset.evaluate(
-                [0] * len(rawframe_dataset), metric_dict=dict(topk=1.0))
+                [0] * len(rawframe_dataset),
+                metric_options=dict(top_k_accuracy=dict(topk=1.)))
 
         with pytest.raises(KeyError):
             # unsupported metric
@@ -527,7 +528,8 @@ class TestDataset:
         with pytest.raises(TypeError):
             # topk must be int or tuple of int
             video_dataset.evaluate(
-                [0] * len(video_dataset), metric_dict=dict(topk=1.0))
+                [0] * len(video_dataset),
+                metric_options=dict(top_k_accuracy=dict(topk=1.)))
 
         with pytest.raises(KeyError):
             # unsupported metric
@@ -843,7 +845,8 @@ class TestDataset:
         with pytest.raises(TypeError):
             # topk must be int or tuple of int
             audio_dataset.evaluate(
-                [0] * len(audio_dataset), metric_dict=dict(topk=1.0))
+                [0] * len(audio_dataset),
+                metric_options=dict(top_k_accuracy=dict(topk=1.)))
 
         with pytest.raises(KeyError):
             # unsupported metric
@@ -873,7 +876,8 @@ class TestDataset:
         with pytest.raises(TypeError):
             # topk must be int or tuple of int
             audio_dataset.evaluate(
-                [0] * len(audio_dataset), metric_dict=dict(topk=1.0))
+                [0] * len(audio_dataset),
+                metric_options=dict(top_k_accuracy=dict(topk=1.)))
 
         with pytest.raises(KeyError):
             # unsupported metric


### PR DESCRIPTION
```python
def evaluate(self,
             ...
             topk=(1, 5),
             ...):
```
to
```python
def evaluate(self,
             ...
             metric_dict=dict(topk=(1, 5)),
             ...):
```
to avoid hardcoded argument for `evaluate`