### PR TITLE
Fixed install

### DIFF
--- a/mmaction/core/lr/__init__.py
+++ b/mmaction/core/lr/__init__.py
@@ -1,0 +1,3 @@
+from .tin_lr_hook import TINLrUpdaterHook
+
+__all__ = ['TINLrUpdaterHook']


### PR DESCRIPTION
Let's say you want to install mmaction2 using `python setup.py install` or `pip install git+https://github.com/open-mmlab/mmaction2.git`
This install is missing a file as shown below

```console
(venv) sebastien@linker:<path_to_your_repo (not mmaction)>$ diff -r -x __pycache__ venv/lib/python3.7/site-packages/mmaction2-0.8.0-py3.7.egg/mmaction/ <path_to_cloned_mmaction2>/mmaction
Only in <path_to_cloned_mmaction2>/mmaction/core: lr
```

This PR is fixing this