### PR TITLE
[Improvement] Update docs about test crops.

### DIFF
--- a/configs/recognition/tsm/README.md
+++ b/configs/recognition/tsm/README.md
@@ -57,7 +57,12 @@ e.g., lr=0.01 for 4 GPUs * 2 video/gpu and lr=0.08 for 16 GPUs * 4 video/gpu.
 2. The **inference_time** is got by this [benchmark script](/tools/analysis/benchmark.py), where we use the sampling frames strategy of the test setting and only care about the model inference time,
 not including the IO time and pre-processing time. For each setting, we use 1 gpu and set batch size (videos per gpu) to 1 to calculate the inference time.
 3. The values in columns named after "reference" are the results got by training on the original repo, using the same model settings. The checkpoints for reference repo can be downloaded [here](https://download.openmmlab.com/mmaction/recognition/tsm/tsm_reference_ckpt.rar).
-4. There are two kinds of test settings for Something-Something dataset, efficient setting (center crop * 1 clip) and accurate setting (Three crop * 2 clip), which is referred from the [original repo](https://github.com/mit-han-lab/temporal-shift-module/tree/8d53d6fda40bea2f1b37a6095279c4b454d672bd).
+4. When using multiple crops for testing, we have to set `cfg.test_cfg['test_crops']` and `cfg.test_cfg['twice_sample']` manually to get correct results. Number of crops is calculated by:
+   1. `twice_sample` in `SampleFrames`
+   2. `num_sample_positions` in `DenseSampleFrames`
+   3. `ThreeCrop/TenCrop/MultiGroupCrop` in `test_pipeline`
+   4. `num_clips` in `SampleFrames` or its subclass if `clip_len != 1`
+5. There are two kinds of test settings for Something-Something dataset, efficient setting (center crop * 1 clip) and accurate setting (Three crop * 2 clip), which is referred from the [original repo](https://github.com/mit-han-lab/temporal-shift-module/tree/8d53d6fda40bea2f1b37a6095279c4b454d672bd).
 We use efficient setting as default provided in config files, and it can be changed to accurate setting by
 ```python
 ...

--- a/configs/recognition/tsm/README.md
+++ b/configs/recognition/tsm/README.md
@@ -57,17 +57,12 @@ e.g., lr=0.01 for 4 GPUs * 2 video/gpu and lr=0.08 for 16 GPUs * 4 video/gpu.
 2. The **inference_time** is got by this [benchmark script](/tools/analysis/benchmark.py), where we use the sampling frames strategy of the test setting and only care about the model inference time,
 not including the IO time and pre-processing time. For each setting, we use 1 gpu and set batch size (videos per gpu) to 1 to calculate the inference time.
 3. The values in columns named after "reference" are the results got by training on the original repo, using the same model settings. The checkpoints for reference repo can be downloaded [here](https://download.openmmlab.com/mmaction/recognition/tsm/tsm_reference_ckpt.rar).
-4. When using multiple crops for testing, we have to set `cfg.test_cfg['test_crops']` and `cfg.test_cfg['twice_sample']` manually to get correct results. Number of crops is calculated by:
-   1. `twice_sample` in `SampleFrames`
-   2. `num_sample_positions` in `DenseSampleFrames`
-   3. `ThreeCrop/TenCrop/MultiGroupCrop` in `test_pipeline`
-   4. `num_clips` in `SampleFrames` or its subclass if `clip_len != 1`
-5. There are two kinds of test settings for Something-Something dataset, efficient setting (center crop * 1 clip) and accurate setting (Three crop * 2 clip), which is referred from the [original repo](https://github.com/mit-han-lab/temporal-shift-module/tree/8d53d6fda40bea2f1b37a6095279c4b454d672bd).
+4. There are two kinds of test settings for Something-Something dataset, efficient setting (center crop * 1 clip) and accurate setting (Three crop * 2 clip), which is referred from the [original repo](https://github.com/mit-han-lab/temporal-shift-module/tree/8d53d6fda40bea2f1b37a6095279c4b454d672bd).
 We use efficient setting as default provided in config files, and it can be changed to accurate setting by
 ```python
 ...
 # `test_cfg = dict(average_clips=None)` for efficient setting
-test_cfg = dict(average_clips='prob', test_crops=3, twice_sample=True)  # for accurate setting
+test_cfg = dict(average_clips='prob')  # for accurate setting
 ...
 test_pipeline = [
     dict(

--- a/configs/recognition/tsm/README.md
+++ b/configs/recognition/tsm/README.md
@@ -61,8 +61,7 @@ not including the IO time and pre-processing time. For each setting, we use 1 gp
 We use efficient setting as default provided in config files, and it can be changed to accurate setting by
 ```python
 ...
-# `test_cfg = dict(average_clips=None)` for efficient setting
-test_cfg = dict(average_clips='prob')  # for accurate setting
+test_cfg = dict(average_clips='prob')
 ...
 test_pipeline = [
     dict(

--- a/configs/recognition/tsm/tsm_nl_dot_product_r50_1x1x8_50e_kinetics400_rgb.py
+++ b/configs/recognition/tsm/tsm_nl_dot_product_r50_1x1x8_50e_kinetics400_rgb.py
@@ -24,7 +24,7 @@ model = dict(
         is_shift=True))
 # model training and testing settings
 train_cfg = None
-test_cfg = dict(average_clips=None)
+test_cfg = dict(average_clips='prob')
 # dataset settings
 dataset_type = 'RawframeDataset'
 data_root = 'data/kinetics400/rawframes_train'

--- a/configs/recognition/tsm/tsm_nl_embedded_gaussian_r50_1x1x8_50e_kinetics400_rgb.py
+++ b/configs/recognition/tsm/tsm_nl_embedded_gaussian_r50_1x1x8_50e_kinetics400_rgb.py
@@ -24,7 +24,7 @@ model = dict(
         is_shift=True))
 # model training and testing settings
 train_cfg = None
-test_cfg = dict(average_clips=None)
+test_cfg = dict(average_clips='prob')
 # dataset settings
 dataset_type = 'RawframeDataset'
 data_root = 'data/kinetics400/rawframes_train'

--- a/configs/recognition/tsm/tsm_nl_gaussian_r50_1x1x8_50e_kinetics400_rgb.py
+++ b/configs/recognition/tsm/tsm_nl_gaussian_r50_1x1x8_50e_kinetics400_rgb.py
@@ -24,7 +24,7 @@ model = dict(
         is_shift=True))
 # model training and testing settings
 train_cfg = None
-test_cfg = dict(average_clips=None)
+test_cfg = dict(average_clips='prob')
 # dataset settings
 dataset_type = 'RawframeDataset'
 data_root = 'data/kinetics400/rawframes_train'

--- a/configs/recognition/tsm/tsm_r101_1x1x8_50e_sthv1_rgb.py
+++ b/configs/recognition/tsm/tsm_r101_1x1x8_50e_sthv1_rgb.py
@@ -18,7 +18,7 @@ model = dict(
         is_shift=True))
 # model training and testing settings
 train_cfg = None
-test_cfg = dict(average_clips=None)
+test_cfg = dict(average_clips='prob')
 # dataset settings
 dataset_type = 'RawframeDataset'
 data_root = 'data/sthv1/rawframes'

--- a/configs/recognition/tsm/tsm_r101_1x1x8_50e_sthv2_rgb.py
+++ b/configs/recognition/tsm/tsm_r101_1x1x8_50e_sthv2_rgb.py
@@ -18,7 +18,7 @@ model = dict(
         is_shift=True))
 # model training and testing settings
 train_cfg = None
-test_cfg = dict(average_clips=None)
+test_cfg = dict(average_clips='prob')
 # dataset settings
 dataset_type = 'RawframeDataset'
 data_root = 'data/sthv2/rawframes'

--- a/configs/recognition/tsm/tsm_r50_1x1x16_50e_kinetics400_rgb.py
+++ b/configs/recognition/tsm/tsm_r50_1x1x16_50e_kinetics400_rgb.py
@@ -20,7 +20,7 @@ model = dict(
         is_shift=True))
 # model training and testing settings
 train_cfg = None
-test_cfg = dict(average_clips=None)
+test_cfg = dict(average_clips='prob')
 # dataset settings
 dataset_type = 'RawframeDataset'
 data_root = 'data/kinetics400/rawframes_train'

--- a/configs/recognition/tsm/tsm_r50_1x1x16_50e_sthv1_rgb.py
+++ b/configs/recognition/tsm/tsm_r50_1x1x16_50e_sthv1_rgb.py
@@ -20,7 +20,7 @@ model = dict(
         is_shift=True))
 # model training and testing settings
 train_cfg = None
-test_cfg = dict(average_clips=None)
+test_cfg = dict(average_clips='prob')
 # dataset settings
 dataset_type = 'RawframeDataset'
 data_root = 'data/sthv1/rawframes'

--- a/configs/recognition/tsm/tsm_r50_1x1x16_50e_sthv2_rgb.py
+++ b/configs/recognition/tsm/tsm_r50_1x1x16_50e_sthv2_rgb.py
@@ -20,7 +20,7 @@ model = dict(
         is_shift=True))
 # model training and testing settings
 train_cfg = None
-test_cfg = dict(average_clips=None)
+test_cfg = dict(average_clips='prob')
 # dataset settings
 dataset_type = 'RawframeDataset'
 data_root = 'data/sthv2/rawframes'

--- a/configs/recognition/tsm/tsm_r50_1x1x8_50e_kinetics400_rgb.py
+++ b/configs/recognition/tsm/tsm_r50_1x1x8_50e_kinetics400_rgb.py
@@ -18,7 +18,7 @@ model = dict(
         is_shift=True))
 # model training and testing settings
 train_cfg = None
-test_cfg = dict(average_clips=None)
+test_cfg = dict(average_clips='prob')
 # dataset settings
 dataset_type = 'RawframeDataset'
 data_root = 'data/kinetics400/rawframes_train'

--- a/configs/recognition/tsm/tsm_r50_1x1x8_50e_sthv1_rgb.py
+++ b/configs/recognition/tsm/tsm_r50_1x1x8_50e_sthv1_rgb.py
@@ -18,7 +18,7 @@ model = dict(
         is_shift=True))
 # model training and testing settings
 train_cfg = None
-test_cfg = dict(average_clips=None)
+test_cfg = dict(average_clips='prob')
 # dataset settings
 dataset_type = 'RawframeDataset'
 data_root = 'data/sthv1/rawframes'

--- a/configs/recognition/tsm/tsm_r50_1x1x8_50e_sthv2_rgb.py
+++ b/configs/recognition/tsm/tsm_r50_1x1x8_50e_sthv2_rgb.py
@@ -18,7 +18,7 @@ model = dict(
         is_shift=True))
 # model training and testing settings
 train_cfg = None
-test_cfg = dict(average_clips=None)
+test_cfg = dict(average_clips='prob')
 # dataset settings
 dataset_type = 'RawframeDataset'
 data_root = 'data/sthv2/rawframes'

--- a/configs/recognition/tsm/tsm_r50_dense_1x1x8_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsm/tsm_r50_dense_1x1x8_100e_kinetics400_rgb.py
@@ -18,7 +18,7 @@ model = dict(
         is_shift=True))
 # model training and testing settings
 train_cfg = None
-test_cfg = dict(average_clips='prob', test_crops=10)
+test_cfg = dict(average_clips='prob')
 # dataset settings
 dataset_type = 'RawframeDataset'
 data_root = 'data/kinetics400/rawframes_train'

--- a/configs/recognition/tsm/tsm_r50_dense_1x1x8_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsm/tsm_r50_dense_1x1x8_100e_kinetics400_rgb.py
@@ -18,7 +18,7 @@ model = dict(
         is_shift=True))
 # model training and testing settings
 train_cfg = None
-test_cfg = dict(average_clips=None)
+test_cfg = dict(average_clips='prob', test_crops=10)
 # dataset settings
 dataset_type = 'RawframeDataset'
 data_root = 'data/kinetics400/rawframes_train'

--- a/configs/recognition/tsm/tsm_r50_video_1x1x8_50e_kinetics400_rgb.py
+++ b/configs/recognition/tsm/tsm_r50_video_1x1x8_50e_kinetics400_rgb.py
@@ -18,7 +18,7 @@ model = dict(
         is_shift=True))
 # model training and testing settings
 train_cfg = None
-test_cfg = dict(average_clips=None)
+test_cfg = dict(average_clips='prob')
 # dataset settings
 dataset_type = 'VideoDataset'
 data_root = 'data/kinetics400/videos_train'

--- a/configs/recognition/tsm/tsm_temporal_pool_r50_1x1x8_50e_kinetics400_rgb.py
+++ b/configs/recognition/tsm/tsm_temporal_pool_r50_1x1x8_50e_kinetics400_rgb.py
@@ -20,7 +20,7 @@ model = dict(
         is_shift=True))
 # model training and testing settings
 train_cfg = None
-test_cfg = dict(average_clips=None)
+test_cfg = dict(average_clips='prob')
 # dataset settings
 dataset_type = 'RawframeDataset'
 data_root = 'data/kinetics400/rawframes_train'

--- a/demo/README.md
+++ b/demo/README.md
@@ -9,7 +9,7 @@
 
 ### Video demo
 
-We provide a demo script to predict the recognition result using a single video.
+We provide a demo script to predict the recognition result using a single video. In order to get predict results in range `[0, 1]`, make sure to set `test_cfg = dict(average_clips='prob')` in config file.
 
 ```shell
 python demo/demo.py ${CONFIG_FILE} ${CHECKPOINT_FILE} ${VIDEO_FILE} {LABEL_FILE} [--use-frames] \
@@ -157,7 +157,7 @@ or use checkpoint url from `configs/` to directly load corresponding checkpoint,
 
 ### Webcam demo
 
-We provide a demo script to implement real-time action recognition from web camera.
+We provide a demo script to implement real-time action recognition from web camera. In order to get predict results in range `[0, 1]`, make sure to set `test_cfg = dict(average_clips='prob')` in config file.
 
 ```shell
 python demo/webcam_demo.py ${CONFIG_FILE} ${CHECKPOINT_FILE} ${LABEL_FILE} \
@@ -212,7 +212,7 @@ Users can change:
 
 ### Long video demo
 
-We provide a demo script to predict different labels using a single long video.
+We provide a demo script to predict different labels using a single long video. In order to get predict results in range `[0, 1]`, make sure to set `test_cfg = dict(average_clips='prob')` in config file.
 
 ```shell
 python demo/long_video_demo.py ${CONFIG_FILE} ${CHECKPOINT_FILE} ${VIDEO_FILE} ${LABEL_FILE} \

--- a/demo/README.md
+++ b/demo/README.md
@@ -5,6 +5,7 @@
   * [Video demo](#video-demo): A demo script to predict the recognition result using a single video
   * [Video GradCAM Demo](#video-gradcam-demo): A demo script to visualize GradCAM results using a single video.
   * [Webcam demo](#webcam-demo): A demo script to implement real-time action recognition from web camera
+  * [Long Video demo](#long-video-demo): a demo script to predict different labels using a single long video.
 
 ### Video demo
 
@@ -138,20 +139,20 @@ or use checkpoint url from `configs/` to directly load corresponding checkpoint,
 
 1. Get GradCAM results of a I3D model, using a video file as input and then generate an gif file with 10 fps.
 
-```shell
-python demo/demo_gradcam.py configs/recognition/i3d/i3d_r50_video_inference_32x2x1_100e_kinetics400_rgb.py \
-    checkpoints/i3d_r50_video_32x2x1_100e_kinetics400_rgb_20200826-e31c6f52.pth demo/demo.mp4 \
-    --target-layer-name backbone/layer4/1/relu --fps 10 \
-    --out-filename demo/demo_gradcam.gif
-```
+    ```shell
+    python demo/demo_gradcam.py configs/recognition/i3d/i3d_r50_video_inference_32x2x1_100e_kinetics400_rgb.py \
+        checkpoints/i3d_r50_video_32x2x1_100e_kinetics400_rgb_20200826-e31c6f52.pth demo/demo.mp4 \
+        --target-layer-name backbone/layer4/1/relu --fps 10 \
+        --out-filename demo/demo_gradcam.gif
+    ```
 
 2. Get GradCAM results of a TSM model, using a video file as input and then generate an gif file, loading checkpoint from url.
 
-```shell
-python demo/demo_gradcam.py configs/recognition/tsm/tsm_r50_video_inference_1x1x8_100e_kinetics400_rgb.py \
-    https://download.openmmlab.com/mmaction/recognition/tsm/tsm_r50_video_1x1x8_100e_kinetics400_rgb/tsm_r50_video_1x1x8_100e_kinetics400_rgb_20200702-a77f4328.pth \
-    demo/demo.mp4 --target-layer-name backbone/layer4/1/relu --out-filename demo/demo_gradcam_tsm.gif
-```
+    ```shell
+    python demo/demo_gradcam.py configs/recognition/tsm/tsm_r50_video_inference_1x1x8_100e_kinetics400_rgb.py \
+        https://download.openmmlab.com/mmaction/recognition/tsm/tsm_r50_video_1x1x8_100e_kinetics400_rgb/tsm_r50_video_1x1x8_100e_kinetics400_rgb_20200702-a77f4328.pth \
+        demo/demo.mp4 --target-layer-name backbone/layer4/1/relu --out-filename demo/demo_gradcam_tsm.gif
+    ```
 
 
 ### Webcam demo
@@ -207,3 +208,59 @@ Users can change:
 1). `SampleFrames` step (especially the number of `clip_len` and `num_clips`) of `test_pipeline` in the config file.
 2). Change to the suitable Crop methods like `TenCrop`, `ThreeCrop`, `CenterCrop`, etc. in `test_pipeline` of the config file.
 3). Change the number of `--average-size`. The smaller, the faster.
+
+
+### Long video demo
+
+We provide a demo script to predict different labels using a single long video.
+
+```shell
+python demo/long_video_demo.py ${CONFIG_FILE} ${CHECKPOINT_FILE} ${VIDEO_FILE} ${LABEL_FILE} \
+    ${OUT_FILE} [--input-step ${INPUT_STEP}] [--device ${DEVICE_TYPE}] [--threshold ${THRESHOLD}]
+```
+
+Optional arguments:
+- `OUT_FILE`: Path to the output video file.
+- `INPUT_STEP`: Input step for sampling frames, which can help to get more spare input. If not specified , it will be set to 1.
+- `DEVICE_TYPE`: Type of device to run the demo. Allowed values are cuda device like `cuda:0` or `cpu`. If not specified, it will be set to `cuda:0`.
+- `THRESHOLD`: Threshold of prediction score for action recognition. Only label with score higher than the threshold will be shown. If not specified, it will be set to 0.01.
+
+Examples:
+
+Assume that you are located at `$MMACTION2` and have already downloaded the checkpoints to the directory `checkpoints/`,
+or use checkpoint url from `configs/` to directly load corresponding checkpoint, which will be automatically saved in `$HOME/.cahe/torch/checkpoints`.
+
+1. Predict different labels in a long video by using a TSN model on cpu, with 3 frames for input steps (that is, random sample one from each 3 frames)
+and outputting result labels with score higher than 0.2.
+
+    ```shell
+    python demo/long_video_demo.py configs/recognition/tsn/tsn_r50_video_inference_1x1x3_100e_kinetics400_rgb.py \
+      checkpoints/tsn_r50_1x1x3_100e_kinetics400_rgb_20200614-e508be42.pth PATH_TO_LONG_VIDEO demo/label_map.txt PATH_TO_SAVED_VIDEO \
+      --input-step 3 --device cpu --threshold 0.2
+    ```
+
+2. Predict different labels in a long video by using a TSN model on cpu, with 3 frames for input steps (that is, random sample one from each 3 frames)
+and outputting result labels with score higher than 0.2, loading checkpoint from url.
+
+    ```shell
+    python demo/long_video_demo.py configs/recognition/tsn/tsn_r50_video_inference_1x1x3_100e_kinetics400_rgb.py \
+      https://download.openmmlab.com/mmaction/recognition/tsn/tsn_r50_1x1x3_100e_kinetics400_rgb/tsn_r50_1x1x3_100e_kinetics400_rgb_20200614-e508be42.pth \
+      PATH_TO_LONG_VIDEO demo/label_map.txt PATH_TO_SAVED_VIDEO --input-step 3 --device cpu --threshold 0.2
+    ```
+
+3. Predict different labels in a long video from web by using a TSN model on cpu, with 3 frames for input steps (that is, random sample one from each 3 frames)
+and outputting result labels with score higher than 0.2, loading checkpoint from url.
+
+    ```shell
+    python demo/long_video_demo.py configs/recognition/tsn/tsn_r50_video_inference_1x1x3_100e_kinetics400_rgb.py \
+      https://download.openmmlab.com/mmaction/recognition/tsn/tsn_r50_1x1x3_100e_kinetics400_rgb/tsn_r50_1x1x3_100e_kinetics400_rgb_20200614-e508be42.pth \
+      https://www.learningcontainer.com/wp-content/uploads/2020/05/sample-mp4-file.mp4 \
+      demo/label_map.txt PATH_TO_SAVED_VIDEO --input-step 3 --device cpu --threshold 0.2
+    ```
+
+4. Predict different labels in a long video by using a I3D model on gpu, with input_step=1 and threshold=0.01 as default.
+
+    ```shell
+    python demo/long_video_demo.py configs/recognition/i3d/i3d_r50_video_inference_32x2x1_100e_kinetics400_rgb.py \
+      checkpoints/i3d_r50_256p_32x2x1_100e_kinetics400_rgb_20200801-7d9f44de.pth PATH_TO_LONG_VIDEO demo/label_map.txt PATH_TO_SAVED_VIDEO \
+    ```

--- a/demo/long_video_demo.py
+++ b/demo/long_video_demo.py
@@ -1,0 +1,178 @@
+import argparse
+import random
+from collections import deque
+from operator import itemgetter
+
+import cv2
+import mmcv
+import numpy as np
+import torch
+from mmcv.parallel import collate, scatter
+
+from mmaction.apis import init_recognizer
+from mmaction.datasets.pipelines import Compose
+
+FONTFACE = cv2.FONT_HERSHEY_COMPLEX_SMALL
+FONTSCALE = 1
+FONTCOLOR = (255, 255, 255)  # BGR, white
+MSGCOLOR = (128, 128, 128)  # BGR, gray
+THICKNESS = 1
+LINETYPE = 1
+
+EXCLUED_STEPS = [
+    'OpenCVInit', 'OpenCVDecode', 'DecordInit', 'DecordDecode', 'PyAVInit',
+    'PyAVDecode', 'RawFrameDecode', 'FrameSelector'
+]
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='MMAction2 predict different labels in a long video demo')
+    parser.add_argument('config', help='test config file path')
+    parser.add_argument('checkpoint', help='checkpoint file/url')
+    parser.add_argument('video', help='video file/url')
+    parser.add_argument('label', help='label file')
+    parser.add_argument('out_file', help='output filename')
+    parser.add_argument(
+        '--input-step',
+        type=int,
+        default=1,
+        help='input step for sampling frames')
+    parser.add_argument(
+        '--device', type=str, default='cuda:0', help='CPU/CUDA device option')
+    parser.add_argument(
+        '--threshold',
+        type=float,
+        default=0.01,
+        help='recognition score threshold')
+    args = parser.parse_args()
+    return args
+
+
+def show_results():
+    cap = cv2.VideoCapture(video_path)
+    num_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    frame_width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    frame_height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    fps = cap.get(cv2.CAP_PROP_FPS)
+
+    msg = 'Preparing action recognition ...'
+    text_info = {}
+    fourcc = cv2.VideoWriter_fourcc(*'mp4v')
+    frame_size = (frame_width, frame_height)
+
+    ind = 0
+    video_writer = cv2.VideoWriter(out_file, fourcc, fps, frame_size)
+    prog_bar = mmcv.ProgressBar(num_frames)
+    backup_frames = []
+
+    while ind < num_frames:
+        ind += 1
+        prog_bar.update()
+        ret, frame = cap.read()
+        backup_frames.append(np.array(frame)[:, :, ::-1])
+        if ind == sample_length:
+            # provide a quick show at the beginning
+            frame_queue.extend(backup_frames)
+            backup_frames = []
+        elif ((len(backup_frames) == input_step and ind > sample_length)
+              or ind == num_frames):
+            # pick a frame from the backup
+            # when the backup is full or reach the last frame
+            chosen_frame = random.choice(backup_frames)
+            backup_frames = []
+            frame_queue.append(chosen_frame)
+
+        ret, scores = inference()
+
+        if ret:
+            num_selected_labels = min(len(label), 5)
+            scores_tuples = tuple(zip(label, scores))
+            scores_sorted = sorted(
+                scores_tuples, key=itemgetter(1), reverse=True)
+            results = scores_sorted[:num_selected_labels]
+            result_queue.append(results)
+
+        if len(result_queue) != 0:
+            text_info = {}
+            results = result_queue.popleft()
+            for i, result in enumerate(results):
+                selected_label, score = result
+                if score < threshold:
+                    break
+                location = (0, 40 + i * 20)
+                text = selected_label + ': ' + str(round(score, 2))
+                text_info[location] = text
+                cv2.putText(frame, text, location, FONTFACE, FONTSCALE,
+                            FONTCOLOR, THICKNESS, LINETYPE)
+        elif len(text_info):
+            for location, text in text_info.items():
+                cv2.putText(frame, text, location, FONTFACE, FONTSCALE,
+                            FONTCOLOR, THICKNESS, LINETYPE)
+        else:
+            cv2.putText(frame, msg, (0, 40), FONTFACE, FONTSCALE, MSGCOLOR,
+                        THICKNESS, LINETYPE)
+        video_writer.write(frame)
+    cap.release()
+    cv2.destroyAllWindows()
+
+
+def inference():
+    if len(frame_queue) != sample_length:
+        # Do no inference when there is no enough frames
+        return False, None
+
+    cur_windows = list(np.array(frame_queue))
+    if data['img_shape'] is None:
+        data['img_shape'] = frame_queue.popleft().shape[:2]
+    frame_queue.popleft()
+    cur_data = data.copy()
+    cur_data['imgs'] = cur_windows
+    cur_data = test_pipeline(cur_data)
+    cur_data = collate([cur_data], samples_per_gpu=1)
+    if next(model.parameters()).is_cuda:
+        cur_data = scatter(cur_data, [device])[0]
+    with torch.no_grad():
+        scores = model(return_loss=False, **cur_data)[0]
+    return True, scores
+
+
+def main():
+    global frame_queue, threshold, sample_length, data, test_pipeline, model, \
+        out_file, video_path, device, input_step, label, result_queue
+
+    args = parse_args()
+    input_step = args.input_step
+    threshold = args.threshold
+    video_path = args.video
+    out_file = args.out_file
+
+    device = torch.device(args.device)
+    model = init_recognizer(args.config, args.checkpoint, device=device)
+    data = dict(img_shape=None, modality='RGB', label=-1)
+    with open(args.label, 'r') as f:
+        label = [line.strip() for line in f]
+
+    # prepare test pipeline from non-camera pipeline
+    cfg = model.cfg
+    sample_length = 0
+    pipeline = cfg.test_pipeline
+    pipeline_ = pipeline.copy()
+    for step in pipeline:
+        if 'SampleFrames' in step['type']:
+            sample_length = step['clip_len'] * step['num_clips']
+            data['num_clips'] = step['num_clips']
+            data['clip_len'] = step['clip_len']
+            pipeline_.remove(step)
+        if step['type'] in EXCLUED_STEPS:
+            # remove step to decode frames
+            pipeline_.remove(step)
+    test_pipeline = Compose(pipeline_)
+    assert sample_length > 0
+    frame_queue = deque(maxlen=sample_length)
+    result_queue = deque(maxlen=1)
+    show_results()
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@
 
 **Improvements**
 - Support PyTorch 1.7 in CI ([#312](https://github.com/open-mmlab/mmaction2/pull/312))
+- Support to predict different labels in a long video ([#274](https://github.com/open-mmlab/mmaction2/pull/274))
 - Add random seed for building filelists ([#323](https://github.com/open-mmlab/mmaction2/pull/323))
 - Move docs about demo to `demo/README.md` ([#329](https://github.com/open-mmlab/mmaction2/pull/329))
 - Remove redundant code in `tools/test.py` ([#310](https://github.com/open-mmlab/mmaction2/pull/310))
@@ -41,6 +42,7 @@
 - Support joint training with multiple training datasets of multiple formats, including images, untrimmed videos, etc. ([#242](https://github.com/open-mmlab/mmaction2/pull/242))
 - Support to specify a start epoch to conduct evaluation ([#216](https://github.com/open-mmlab/mmaction2/pull/216))
 - Implement X3D models, support testing with model weights converted from SlowFast ([#288](https://github.com/open-mmlab/mmaction2/pull/288))
+- Support specify a start epoch to conduct evaluation ([#216](https://github.com/open-mmlab/mmaction2/pull/216))
 
 **Improvements**
 - Set default values of 'average_clips' in each config file so that there is no need to set it explicitly during testing in most cases ([#232](https://github.com/open-mmlab/mmaction2/pull/232))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,7 @@
 - Add random seed for building filelists ([#323](https://github.com/open-mmlab/mmaction2/pull/323))
 - Move docs about demo to `demo/README.md` ([#329](https://github.com/open-mmlab/mmaction2/pull/329))
 - Remove redundant code in `tools/test.py` ([#310](https://github.com/open-mmlab/mmaction2/pull/310))
+- Automatically calculate number of test clips for Recognizer2D ([#359](https://github.com/open-mmlab/mmaction2/pull/359))
 
 **Bug Fixes**
 - Fix a bug in BaseDataset when `data_prefix` is None ([#314](https://github.com/open-mmlab/mmaction2/pull/314))

--- a/mmaction/datasets/pipelines/loading.py
+++ b/mmaction/datasets/pipelines/loading.py
@@ -323,7 +323,8 @@ class DenseSampleFrames(SampleFrames):
         sample_range (int): Total sample range for dense sample.
             Default: 64.
         num_sample_positions (int): Number of sample start positions, Which is
-            only used in test mode. Default: 10.
+            only used in test mode. Default: 10. That is to say, by default,
+            there are at least 10 crops for one input sample in test mode.
         temporal_jitter (bool): Whether to apply temporal jittering.
             Default: False.
         test_mode (bool): Store True when building test or validation dataset.

--- a/mmaction/datasets/pipelines/loading.py
+++ b/mmaction/datasets/pipelines/loading.py
@@ -324,7 +324,7 @@ class DenseSampleFrames(SampleFrames):
             Default: 64.
         num_sample_positions (int): Number of sample start positions, Which is
             only used in test mode. Default: 10. That is to say, by default,
-            there are at least 10 crops for one input sample in test mode.
+            there are at least 10 clips for one input sample in test mode.
         temporal_jitter (bool): Whether to apply temporal jittering.
             Default: False.
         test_mode (bool): Store True when building test or validation dataset.

--- a/mmaction/models/heads/tsm_head.py
+++ b/mmaction/models/heads/tsm_head.py
@@ -78,9 +78,11 @@ class TSMHead(BaseHead):
 
         Args:
             x (torch.Tensor): The input data.
-            num_segments (int): Useless in TSMHead.
-                Use `self.num_segments` instead.
-
+            num_segments (int): Useless in TSMHead. By default, `num_segments`
+                is equal to `clip_len * num_clips * num_crops`, which is
+                automatically generated in Recognizer forward phase and
+                useless in TSM models. The `self.num_segments` we need is a
+                hyper parameter to build TSM models.
         Returns:
             torch.Tensor: The classification scores for input samples.
         """

--- a/mmaction/models/heads/tsm_head.py
+++ b/mmaction/models/heads/tsm_head.py
@@ -73,12 +73,12 @@ class TSMHead(BaseHead):
         """Initiate the parameters from scratch."""
         normal_init(self.fc_cls, std=self.init_std)
 
-    def forward(self, x, num_segments):
+    def forward(self, x, num_segs):
         """Defines the computation performed at every call.
 
         Args:
             x (torch.Tensor): The input data.
-            num_segments (int): Useless in TSMHead. By default, `num_segments`
+            num_segs (int): Useless in TSMHead. By default, `num_segs`
                 is equal to `clip_len * num_clips * num_crops`, which is
                 automatically generated in Recognizer forward phase and
                 useless in TSM models. The `self.num_segments` we need is a

--- a/mmaction/models/heads/tsm_head.py
+++ b/mmaction/models/heads/tsm_head.py
@@ -78,7 +78,8 @@ class TSMHead(BaseHead):
 
         Args:
             x (torch.Tensor): The input data.
-            num_segments (int): Number of frame segments. Default: 8.
+            num_segments (int): Useless in TSMHead. 
+                Use `self.num_segments` instead.
 
         Returns:
             torch.Tensor: The classification scores for input samples.

--- a/mmaction/models/recognizers/base.py
+++ b/mmaction/models/recognizers/base.py
@@ -72,7 +72,7 @@ class BaseRecognizer(nn.Module, metaclass=ABCMeta):
         x = self.backbone(imgs)
         return x
 
-    def average_clip(self, cls_score, num_segments=1):
+    def average_clip(self, cls_score, num_segs=1):
         """Averaging class score over multiple clips.
 
         Using different averaging types ('score' or 'prob' or None,
@@ -81,7 +81,7 @@ class BaseRecognizer(nn.Module, metaclass=ABCMeta):
 
         Args:
             cls_score (torch.Tensor): Class score to be averaged.
-            num_segments (int): Number of clips for each input sample.
+            num_segs (int): Number of clips for each input sample.
 
         Returns:
             torch.Tensor: Averaged class score.
@@ -99,8 +99,7 @@ class BaseRecognizer(nn.Module, metaclass=ABCMeta):
             return cls_score
 
         batch_size = cls_score.shape[0]
-        cls_score = cls_score.view(batch_size // num_segments, num_segments,
-                                   -1)
+        cls_score = cls_score.view(batch_size // num_segs, num_segs, -1)
 
         if average_clips == 'prob':
             cls_score = F.softmax(cls_score, dim=2).mean(dim=1)

--- a/mmaction/models/recognizers/base.py
+++ b/mmaction/models/recognizers/base.py
@@ -72,7 +72,7 @@ class BaseRecognizer(nn.Module, metaclass=ABCMeta):
         x = self.backbone(imgs)
         return x
 
-    def average_clip(self, cls_score, num_segs=1):
+    def average_clip(self, cls_score, num_segments=1):
         """Averaging class score over multiple clips.
 
         Using different averaging types ('score' or 'prob' or None,
@@ -81,7 +81,7 @@ class BaseRecognizer(nn.Module, metaclass=ABCMeta):
 
         Args:
             cls_score (torch.Tensor): Class score to be averaged.
-            num_segs (int): Number of clips for each input sample.
+            num_segments (int): Number of clips for each input sample.
 
         Returns:
             torch.Tensor: Averaged class score.
@@ -99,7 +99,8 @@ class BaseRecognizer(nn.Module, metaclass=ABCMeta):
             return cls_score
 
         batch_size = cls_score.shape[0]
-        cls_score = cls_score.view(batch_size // num_segs, num_segs, -1)
+        cls_score = cls_score.view(batch_size // num_segments, num_segments,
+                                   -1)
 
         if average_clips == 'prob':
             cls_score = F.softmax(cls_score, dim=2).mean(dim=1)

--- a/mmaction/models/recognizers/base.py
+++ b/mmaction/models/recognizers/base.py
@@ -82,9 +82,6 @@ class BaseRecognizer(nn.Module, metaclass=ABCMeta):
         Args:
             cls_score (torch.Tensor): Class score to be averaged.
             num_segs (int): Number of clips for each input sample.
-                For Recognizer3D, `num_segs` is set automatically.
-                For Recognizer2D, `num_segs` HAS TO BE SET MANUALLY by
-                `test_crops` and `twice_sample` in cfg.test_cfg.
 
         Returns:
             torch.Tensor: Averaged class score.

--- a/mmaction/models/recognizers/base.py
+++ b/mmaction/models/recognizers/base.py
@@ -77,10 +77,14 @@ class BaseRecognizer(nn.Module, metaclass=ABCMeta):
 
         Using different averaging types ('score' or 'prob' or None,
         which defined in test_cfg) to computed the final averaged
-        class score.
+        class score. Only called in test mode.
 
         Args:
             cls_score (torch.Tensor): Class score to be averaged.
+            num_segs (int): Number of clips for each input sample. 
+                For Recognizer3D, `num_segs` is set automatically.
+                For Recognizer2D, `num_segs` HAS TO BE SET MANUALLY by 
+                `test_crops` and `twice_sample` in cfg.test_cfg.
 
         Returns:
             torch.Tensor: Averaged class score.

--- a/mmaction/models/recognizers/recognizer2d.py
+++ b/mmaction/models/recognizers/recognizer2d.py
@@ -64,10 +64,9 @@ class Recognizer2D(BaseRecognizer):
         cls_score = self.cls_head(x, num_segs)
 
         assert cls_score.size()[0] % batches == 0
-        if cls_score.size()[0] != batches:
-            # calculate num_crops automatically
-            cls_score = self.average_clip(cls_score,
-                                          cls_score.size()[0] // batches)
+        # calculate num_crops automatically
+        cls_score = self.average_clip(cls_score,
+                                      cls_score.size()[0] // batches)
 
         return cls_score
 

--- a/mmaction/models/recognizers/recognizer3d.py
+++ b/mmaction/models/recognizers/recognizer3d.py
@@ -23,9 +23,9 @@ class Recognizer3D(BaseRecognizer):
 
         return losses
 
-    def forward_test(self, imgs):
-        """Defines the computation performed at every call when evaluation and
-        testing."""
+    def _do_test(self, imgs):
+        """Defines the computation performed at every call when evaluation,
+        testing and gradcam"""
         num_segs = imgs.shape[1]
         imgs = imgs.reshape((-1, ) + imgs.shape[2:])
 
@@ -36,7 +36,12 @@ class Recognizer3D(BaseRecognizer):
         cls_score = self.cls_head(x)
         cls_score = self.average_clip(cls_score, num_segs)
 
-        return cls_score.cpu().numpy()
+        return cls_score
+
+    def forward_test(self, imgs):
+        """Defines the computation performed at every call when evaluation and
+        testing."""
+        return self._do_test(imgs).cpu().numpy()
 
     def forward_dummy(self, imgs):
         """Used for computing network FLOPs.
@@ -58,14 +63,4 @@ class Recognizer3D(BaseRecognizer):
     def forward_gradcam(self, imgs):
         """Defines the computation performed at every call when using gradcam
         utils."""
-        num_segs = imgs.shape[1]
-        imgs = imgs.reshape((-1, ) + imgs.shape[2:])
-
-        x = self.extract_feat(imgs)
-        if hasattr(self, 'neck'):
-            x, _ = self.neck(x)
-
-        cls_score = self.cls_head(x)
-        cls_score = self.average_clip(cls_score, num_segs)
-
-        return cls_score
+        return self._do_test(imgs)

--- a/tests/test_gradcam.py
+++ b/tests/test_gradcam.py
@@ -194,7 +194,7 @@ def test_tsm():
     _do_test_2D_models(recognizer, target_layer_name, input_shape)
 
     # test twice sample + 3 crops, 2*3*8=48
-    test_cfg = dict(average_clips='prob', test_crops=3, twice_sample=True)
+    test_cfg = dict(average_clips='prob')
     recognizer = build_recognizer(config.model, test_cfg=test_cfg)
     recognizer.cfg = config
     input_shape = (1, 48, 3, 32, 32)

--- a/tests/test_models/test_recognizers.py
+++ b/tests/test_models/test_recognizers.py
@@ -300,7 +300,7 @@ def test_tsm():
     demo_inputs = generate_demo_inputs(input_shape)
     imgs = demo_inputs['imgs']
 
-    test_cfg = dict(average_clips='prob', test_crops=3, twice_sample=True)
+    test_cfg = dict(average_clips='prob')
     recognizer = build_recognizer(
         model, train_cfg=train_cfg, test_cfg=test_cfg)
 

--- a/tests/test_models/test_recognizers.py
+++ b/tests/test_models/test_recognizers.py
@@ -82,13 +82,13 @@ def test_base_recognizer():
     # average_clips='score'
     test_cfg = dict(average_clips='score')
     recognizer = ExampleRecognizer(None, test_cfg)
-    score = recognizer.average_clip(cls_score, num_segs=5)
+    score = recognizer.average_clip(cls_score, num_segments=5)
     assert torch.equal(score, cls_score.mean(dim=0, keepdim=True))
 
     # average_clips='prob'
     test_cfg = dict(average_clips='prob')
     recognizer = ExampleRecognizer(None, test_cfg)
-    score = recognizer.average_clip(cls_score, num_segs=5)
+    score = recognizer.average_clip(cls_score, num_segments=5)
     assert torch.equal(score,
                        F.softmax(cls_score, dim=1).mean(dim=0, keepdim=True))
 

--- a/tests/test_models/test_recognizers.py
+++ b/tests/test_models/test_recognizers.py
@@ -82,13 +82,13 @@ def test_base_recognizer():
     # average_clips='score'
     test_cfg = dict(average_clips='score')
     recognizer = ExampleRecognizer(None, test_cfg)
-    score = recognizer.average_clip(cls_score, num_segments=5)
+    score = recognizer.average_clip(cls_score, num_segs=5)
     assert torch.equal(score, cls_score.mean(dim=0, keepdim=True))
 
     # average_clips='prob'
     test_cfg = dict(average_clips='prob')
     recognizer = ExampleRecognizer(None, test_cfg)
-    score = recognizer.average_clip(cls_score, num_segments=5)
+    score = recognizer.average_clip(cls_score, num_segs=5)
     assert torch.equal(score,
                        F.softmax(cls_score, dim=1).mean(dim=0, keepdim=True))
 


### PR DESCRIPTION
## BUG
+ Describe bug: Try to run `tools/test.py` with TSM model and `DenseSampleFrames` with default [config](https://github.com/open-mmlab/mmaction2/blob/master/configs/recognition/tsm/tsm_r50_dense_1x1x8_100e_kinetics400_rgb.py) and [checkpoint](https://download.openmmlab.com/mmaction/recognition/tsm/tsm_r50_dense_1x1x8_100e_kinetics400_rgb/tsm_r50_dense_1x1x8_100e_kinetics400_rgb_20200626-91a54551.pth), but failed. 
+ Solution: Finally I find that, when using TSM models, we HAVE TO SET `test_cfg['test_crops']` MANUALLY to get correct results.
+ Thoughts: Maybe we should find a way to set `test_crops` automatically, not manually, like `Recognizer3D` models?

## TODO
+ [x] In order to let users to have better understanding about test crops, add more docs about this.
+ [x] Update TSM DenseSampleFrames default params.
+ [x] calculate num_segs for Recoginizer2D models automatically.
+ [x] changelog