### PR TITLE
fix rename kinetics classnames bug [#374]

### DIFF
--- a/tools/data/kinetics/preparing_kinetics.md
+++ b/tools/data/kinetics/preparing_kinetics.md
@@ -34,15 +34,7 @@ bash download_videos.sh ${DATASET}
 ```
 
 If you have already have a backup of the dataset using the download script above,
-you only need to replace all whitespaces in the class name for ease of processing either by [detox](http://manpages.ubuntu.com/manpages/bionic/man1/detox.1.html)
-
-```shell
-# sudo apt-get install detox
-detox -r ../../../data/${DATASET}/videos_train/
-detox -r ../../../data/${DATASET}/videos_val/
-```
-
-or running
+you only need to replace all whitespaces in the class name for ease of processing by running
 
 ```shell
 bash rename_classnames.sh ${DATASET}

--- a/tools/data/kinetics/preparing_kinetics.md
+++ b/tools/data/kinetics/preparing_kinetics.md
@@ -33,8 +33,8 @@ The codes are adapted from the [official crawler](https://github.com/activitynet
 bash download_videos.sh ${DATASET}
 ```
 
-If you have already have a backup of the dataset using the download script above,
-you only need to replace all whitespaces in the class name for ease of processing by running
+**Important**: If you have already downloaded video dataset using the download script above,
+you must replace all whitespaces in the class name for ease of processing by running
 
 ```shell
 bash rename_classnames.sh ${DATASET}

--- a/tools/data/kinetics/rename_classnames.sh
+++ b/tools/data/kinetics/rename_classnames.sh
@@ -11,7 +11,7 @@ fi
 
 cd ../../../data/${DATASET}/
 ls ./videos_train | while read class; do \
-  newclass=`echo $class | tr " " "_" | tr "(" "-" | tr ")" "-" `;
+  newclass=`echo $class | tr " " "_" `;
   if [ "${class}" != "${newclass}" ]
   then
     mv "videos_train/${class}" "videos_train/${newclass}";
@@ -19,7 +19,7 @@ ls ./videos_train | while read class; do \
 done
 
 ls ./videos_val | while read class; do \
-  newclass=`echo $class | tr " " "_" | tr "(" "-" | tr ")" "-" `;
+  newclass=`echo $class | tr " " "_" `;
   if [ "${class}" != "${newclass}" ]
   then
     mv "videos_val/${class}" "videos_val/${newclass}";


### PR DESCRIPTION
Previous `rename_classnames.sh` and `detox` can rename the
`(` and `)` to `-`, which is not desirable as mentioned in [#374](https://github.com/open-mmlab/mmaction2/issues/374#issue-749310860)