### PR TITLE
[Improvement] improve webcam demo cpu utility.

### DIFF
--- a/demo/webcam_demo.py
+++ b/demo/webcam_demo.py
@@ -167,9 +167,7 @@ def main():
         pr = Thread(target=inference, args=(), daemon=True)
         pw.start()
         pr.start()
-        while True:
-            if not pw.is_alive():
-                exit(0)
+        pw.join()
     except KeyboardInterrupt:
         pass
 


### PR DESCRIPTION
## Description
I implement single thread version of webcam demo, which is similar to `demo/long_video_demo.py`. Compared to `demo/webcam_demo.py`, I find that single thread version's CPU utility **significantly increased**, 100%-200%(`demo/webcam_demo.py`) to 500%-600%(single thread version).

## Results
After some debugging, I find the performance bottleneck are the codes bellow.
```python
# should use pw.join() instead
while True:
        if not pw.is_alive():
            exit(0)
```

Cpu utility is copy from `top`. environment (i5 + 32G + 1080ti), cpu utility increases from `100%-200%` to `400%-500%`, gpu utility increases from 1% to 50%.

test webcam sample is from `demo/README.md`: 
```shell
python demo/webcam_demo.py configs/recognition/tsn/tsn_r50_video_inference_1x1x3_100e_kinetics400_rgb.py \
      https://download.openmmlab.com/mmaction/recognition/tsn/tsn_r50_1x1x3_100e_kinetics400_rgb/tsn_r50_1x1x3_100e_kinetics400_rgb_20200614-e508be42.pth \
      demo/label_map.txt --average-size 5 --threshold 0.2
```