### PR TITLE
[Refactor] refactor EvalHook

### DIFF
--- a/configs/detection/ava/slowfast_context_kinetics_pretrained_r50_4x16x1_20e_ava_rgb.py
+++ b/configs/detection/ava/slowfast_context_kinetics_pretrained_r50_4x16x1_20e_ava_rgb.py
@@ -159,7 +159,7 @@ lr_config = dict(
 total_epochs = 20
 checkpoint_config = dict(interval=1)
 workflow = [('train', 1)]
-evaluation = dict(interval=1, key_indicator='mAP@0.5IOU')
+evaluation = dict(interval=1, save_best='mAP@0.5IOU')
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/configs/detection/ava/slowfast_kinetics_pretrained_r50_4x16x1_20e_ava_rgb.py
+++ b/configs/detection/ava/slowfast_kinetics_pretrained_r50_4x16x1_20e_ava_rgb.py
@@ -158,7 +158,7 @@ lr_config = dict(
 total_epochs = 20
 checkpoint_config = dict(interval=1)
 workflow = [('train', 1)]
-evaluation = dict(interval=1, key_indicator='mAP@0.5IOU')
+evaluation = dict(interval=1, save_best='mAP@0.5IOU')
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/configs/detection/ava/slowfast_kinetics_pretrained_r50_8x8x1_20e_ava_rgb.py
+++ b/configs/detection/ava/slowfast_kinetics_pretrained_r50_8x8x1_20e_ava_rgb.py
@@ -158,7 +158,7 @@ lr_config = dict(
 total_epochs = 20
 checkpoint_config = dict(interval=1)
 workflow = [('train', 1)]
-evaluation = dict(interval=1, key_indicator='mAP@0.5IOU')
+evaluation = dict(interval=1, save_best='mAP@0.5IOU')
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/configs/detection/ava/slowonly_kinetics_pretrained_r101_8x8x1_20e_ava_rgb.py
+++ b/configs/detection/ava/slowonly_kinetics_pretrained_r101_8x8x1_20e_ava_rgb.py
@@ -143,7 +143,7 @@ lr_config = dict(
 total_epochs = 20
 checkpoint_config = dict(interval=1)
 workflow = [('train', 1)]
-evaluation = dict(interval=1, key_indicator='mAP@0.5IOU')
+evaluation = dict(interval=1, save_best='mAP@0.5IOU')
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/configs/detection/ava/slowonly_kinetics_pretrained_r50_4x16x1_20e_ava_rgb.py
+++ b/configs/detection/ava/slowonly_kinetics_pretrained_r50_4x16x1_20e_ava_rgb.py
@@ -142,7 +142,7 @@ lr_config = dict(
 total_epochs = 20
 checkpoint_config = dict(interval=1)
 workflow = [('train', 1)]
-evaluation = dict(interval=1, key_indicator='mAP@0.5IOU')
+evaluation = dict(interval=1, save_best='mAP@0.5IOU')
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/configs/detection/ava/slowonly_omnisource_pretrained_r101_8x8x1_20e_ava_rgb.py
+++ b/configs/detection/ava/slowonly_omnisource_pretrained_r101_8x8x1_20e_ava_rgb.py
@@ -142,7 +142,7 @@ lr_config = dict(
 total_epochs = 20
 checkpoint_config = dict(interval=1)
 workflow = [('train', 1)]
-evaluation = dict(interval=1, key_indicator='mAP@0.5IOU')
+evaluation = dict(interval=1, save_best='mAP@0.5IOU')
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/configs/detection/ava/slowonly_omnisource_pretrained_r50_4x16x1_20e_ava_rgb.py
+++ b/configs/detection/ava/slowonly_omnisource_pretrained_r50_4x16x1_20e_ava_rgb.py
@@ -143,7 +143,7 @@ lr_config = dict(
 total_epochs = 20
 checkpoint_config = dict(interval=1)
 workflow = [('train', 1)]
-evaluation = dict(interval=1, key_indicator='mAP@0.5IOU')
+evaluation = dict(interval=1, save_best='mAP@0.5IOU')
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/docs/tutorials/7_customize_runtime.md
+++ b/docs/tutorials/7_customize_runtime.md
@@ -191,7 +191,7 @@ We support many other learning rate schedule [here](https://github.com/open-mmla
 
 ## Customize Workflow
 
-By default, we recommend users to use `EpochEvalHook` to do evaluation after training epoch, but they can still use `val` workflow as an alternative.
+By default, we recommend users to use `EvalHook` to do evaluation after training epoch, but they can still use `val` workflow as an alternative.
 
 Workflow is a list of (phase, epochs) to specify the running order and epochs. By default it is set to be
 
@@ -213,7 +213,7 @@ so that 1 epoch for training and 1 epoch for validation will be run iteratively.
 
 1. The parameters of model will not be updated during val epoch.
 2. Keyword `total_epochs` in the config only controls the number of training epochs and will not affect the validation workflow.
-3. Workflows `[('train', 1), ('val', 1)]` and `[('train', 1)]` will not change the behavior of `EpochEvalHook` because `EpochEvalHook` is called by `after_train_epoch` and validation workflow only affect hooks that are called through `after_val_epoch`.
+3. Workflows `[('train', 1), ('val', 1)]` and `[('train', 1)]` will not change the behavior of `EvalHook` because `EvalHook` is called by `after_train_epoch` and validation workflow only affect hooks that are called through `after_val_epoch`.
    Therefore, the only difference between `[('train', 1), ('val', 1)]` and ``[('train', 1)]`` is that the runner will calculate losses on validation set after each training epoch.
 
 ## Customize Hooks
@@ -344,7 +344,7 @@ log_config = dict(
 
 #### Evaluation config
 
-The config of `evaluation` will be used to initialize the [`EpochEvalHook`](https://github.com/open-mmlab/mmaction2/blob/master/mmaction/core/evaluation/eval_hooks.py#L12).
+The config of `evaluation` will be used to initialize the [`EvalHook`](https://github.com/open-mmlab/mmaction2/blob/master/mmaction/core/evaluation/eval_hooks.py#L12).
 Except the key `interval`, other arguments such as `metrics` will be passed to the `dataset.evaluate()`
 
 ```python

--- a/mmaction/apis/train.py
+++ b/mmaction/apis/train.py
@@ -6,8 +6,8 @@ from mmcv.runner import (DistSamplerSeedHook, EpochBasedRunner, OptimizerHook,
                          build_optimizer)
 from mmcv.runner.hooks import Fp16OptimizerHook
 
-from ..core import (DistEpochEvalHook, EpochEvalHook,
-                    OmniSourceDistSamplerSeedHook, OmniSourceRunner)
+from ..core import (DistEvalHook, EvalHook, OmniSourceDistSamplerSeedHook,
+                    OmniSourceRunner)
 from ..datasets import build_dataloader, build_dataset
 from ..utils import PreciseBNHook, get_root_logger
 
@@ -143,7 +143,7 @@ def train_model(model,
         dataloader_setting = dict(dataloader_setting,
                                   **cfg.data.get('val_dataloader', {}))
         val_dataloader = build_dataloader(val_dataset, **dataloader_setting)
-        eval_hook = DistEpochEvalHook if distributed else EpochEvalHook
+        eval_hook = DistEvalHook if distributed else EvalHook
         runner.register_hook(eval_hook(val_dataloader, **eval_cfg))
 
     if cfg.resume_from:

--- a/mmaction/core/evaluation/__init__.py
+++ b/mmaction/core/evaluation/__init__.py
@@ -5,13 +5,12 @@ from .accuracy import (average_precision_at_temporal_iou,
                        mmit_mean_average_precision, pairwise_temporal_iou,
                        softmax, top_k_accuracy)
 from .eval_detection import ActivityNetLocalization
-from .eval_hooks import DistEpochEvalHook, EpochEvalHook
+from .eval_hooks import DistEvalHook, EvalHook
 
 __all__ = [
-    'DistEpochEvalHook', 'EpochEvalHook', 'top_k_accuracy',
-    'mean_class_accuracy', 'confusion_matrix', 'mean_average_precision',
-    'get_weighted_score', 'average_recall_at_avg_proposals',
-    'pairwise_temporal_iou', 'average_precision_at_temporal_iou',
-    'ActivityNetLocalization', 'softmax', 'interpolated_precision_recall',
-    'mmit_mean_average_precision'
+    'DistEvalHook', 'EvalHook', 'top_k_accuracy', 'mean_class_accuracy',
+    'confusion_matrix', 'mean_average_precision', 'get_weighted_score',
+    'average_recall_at_avg_proposals', 'pairwise_temporal_iou',
+    'average_precision_at_temporal_iou', 'ActivityNetLocalization', 'softmax',
+    'interpolated_precision_recall', 'mmit_mean_average_precision'
 ]

--- a/mmaction/core/evaluation/eval_hooks.py
+++ b/mmaction/core/evaluation/eval_hooks.py
@@ -332,3 +332,21 @@ class DistEvalHook(EvalHook):
 
             if self.save_best:
                 self._save_ckpt(runner, key_score)
+
+
+class EpochEvalHook(EvalHook):
+    """Deprecated class for ``EvalHook``."""
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn('"EpochEvalHook" is deprecated, please switch to'
+                      '"EvalHook"')
+        super().__init__(*args, **kwargs)
+
+
+class DistEpochEvalHook(DistEvalHook):
+    """Deprecated class for ``DistEvalHook``."""
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn('"DistEpochEvalHook" is deprecated, please switch to'
+                      '"DistEvalHook"')
+        super().__init__(*args, **kwargs)

--- a/mmaction/core/evaluation/eval_hooks.py
+++ b/mmaction/core/evaluation/eval_hooks.py
@@ -147,11 +147,13 @@ class EvalHook(Hook):
 
     def after_train_iter(self, runner):
         """Called after every training iter to evaluate the results."""
-        self._do_evaluate(runner)
+        if not self.by_epoch:
+            self._do_evaluate(runner)
 
     def after_train_epoch(self, runner):
         """Called after every training epoch to evaluate the results."""
-        self._do_evaluate(runner)
+        if self.by_epoch:
+            self._do_evaluate(runner)
 
     def _do_evaluate(self, runner):
         """perform evaluation and save ckpt."""

--- a/mmaction/core/evaluation/eval_hooks.py
+++ b/mmaction/core/evaluation/eval_hooks.py
@@ -200,16 +200,16 @@ class EvalHook(Hook):
     def _save_ckpt(self, runner, key_score):
         if self.by_epoch:
             current = f'epoch_{runner.epoch + 1}'
+            cur_type, cur_time = 'epoch', runner.epoch + 1
         else:
             current = f'iter_{runner.iter + 1}'
+            cur_type, cur_time = 'iter', runner.iter + 1
 
         best_score = runner.meta['hook_msgs'].get(
             'best_score', self.init_value_map[self.rule])
         if self.compare_func(key_score, best_score):
             best_score = key_score
             runner.meta['hook_msgs']['best_score'] = best_score
-            last_ckpt = runner.meta['hook_msgs']['last_ckpt']
-            runner.meta['hook_msgs']['best_ckpt'] = last_ckpt
 
             if self.best_ckpt_path and osp.isfile(self.best_ckpt_path):
                 os.remove(self.best_ckpt_path)
@@ -219,10 +219,12 @@ class EvalHook(Hook):
                 runner.work_dir, best_ckpt_name, create_symlink=False)
             self.best_ckpt_path = osp.join(runner.work_dir, best_ckpt_name)
 
+            runner.meta['hook_msgs']['best_ckpt'] = self.best_ckpt_path
             runner.logger.info(
-                f'Now best checkpoint is saved as {best_ckpt_name}.'
-                f'Best {self.key_indicator} is {best_score:0.4f} at {current}.'
-            )
+                f'Now best checkpoint is saved as {best_ckpt_name}.')
+            runner.logger.info(
+                f'Best {self.key_indicator} is {best_score:0.4f} '
+                f'at {cur_time} {cur_type}.')
 
     def evaluate(self, runner, results):
         """Evaluate the results.

--- a/mmaction/core/evaluation/eval_hooks.py
+++ b/mmaction/core/evaluation/eval_hooks.py
@@ -63,6 +63,13 @@ class EvalHook(Hook):
                  save_best=None,
                  rule=None,
                  **eval_kwargs):
+        if 'key_indicator' in eval_kwargs:
+            raise RuntimeError(
+                '"key_indicator" is deprecated, '
+                'you need to use "save_best" instead. '
+                'See https://github.com/open-mmlab/mmaction2/pull/395 for more info'  # noqa: E501
+            )
+
         if not isinstance(dataloader, DataLoader):
             raise TypeError(f'dataloader must be a pytorch DataLoader, '
                             f'but got {type(dataloader)}')

--- a/mmaction/core/evaluation/eval_hooks.py
+++ b/mmaction/core/evaluation/eval_hooks.py
@@ -34,10 +34,17 @@ class EvalHook(Hook):
              ``top1_acc``, ``top5_acc``, ``mean_class_accuracy``,
             ``mean_average_precision``, ``mmit_mean_average_precision``
             for action recognition dataset (RawframeDataset and VideoDataset).
+<<<<<<< HEAD
             ``AR@AN``, ``auc`` for action localization dataset.
             (ActivityNetDataset). ``Recall@0.5@100``, ``AR@100``,
             ``mAP@0.5IOU`` for spatio-temporal action detection dataset
             (AVADataset). Default: `top1_acc`.
+=======
+            ``AR@AN``, ``auc`` for action localization dataset
+            (ActivityNetDataset). If ``save_best`` is ``auto``, the first key
+             of the returned ``OrderedDict`` result will be used. The interval
+             of ``CheckpointHook`` should device EvalHook. Default: None.
+>>>>>>> polish again
         rule (str | None, optional): Comparison rule for best score. If set to
             None, it will infer a reasonable rule. Keys such as 'acc', 'top'
             .etc will be inferred by 'greater' rule. Keys contain 'loss' will
@@ -254,8 +261,8 @@ class DistEvalHook(EvalHook):
             for action recognition dataset (RawframeDataset and VideoDataset).
             ``AR@AN``, ``auc`` for action localization dataset
             (ActivityNetDataset). If ``save_best`` is ``auto``, the first key
-            will be used. The interval of ``CheckpointHook`` should device
-            EvalHook. Default: None.
+            of the returned ``OrderedDict`` result will be used. The interval
+            of ``CheckpointHook`` should device EvalHook. Default: None.
         rule (str | None, optional): Comparison rule for best score. If set to
             None, it will infer a reasonable rule. Keys such as 'acc', 'top'
             .etc will be inferred by 'greater' rule. Keys contain 'loss' will

--- a/mmaction/core/evaluation/eval_hooks.py
+++ b/mmaction/core/evaluation/eval_hooks.py
@@ -34,17 +34,13 @@ class EvalHook(Hook):
              ``top1_acc``, ``top5_acc``, ``mean_class_accuracy``,
             ``mean_average_precision``, ``mmit_mean_average_precision``
             for action recognition dataset (RawframeDataset and VideoDataset).
-<<<<<<< HEAD
             ``AR@AN``, ``auc`` for action localization dataset.
             (ActivityNetDataset). ``Recall@0.5@100``, ``AR@100``,
             ``mAP@0.5IOU`` for spatio-temporal action detection dataset
-            (AVADataset). Default: `top1_acc`.
-=======
-            ``AR@AN``, ``auc`` for action localization dataset
-            (ActivityNetDataset). If ``save_best`` is ``auto``, the first key
+            (AVADataset). If ``save_best`` is ``auto``, the first key
              of the returned ``OrderedDict`` result will be used. The interval
-             of ``CheckpointHook`` should device EvalHook. Default: None.
->>>>>>> polish again
+             of ``EvalHook`` should be divisible by that of ``CheckpointHook``.
+             Default: 'top1_acc'.
         rule (str | None, optional): Comparison rule for best score. If set to
             None, it will infer a reasonable rule. Keys such as 'acc', 'top'
             .etc will be inferred by 'greater' rule. Keys contain 'loss' will
@@ -273,7 +269,8 @@ class DistEvalHook(EvalHook):
             ``AR@AN``, ``auc`` for action localization dataset
             (ActivityNetDataset). If ``save_best`` is ``auto``, the first key
             of the returned ``OrderedDict`` result will be used. The interval
-            of ``CheckpointHook`` should device EvalHook. Default: None.
+            of ``EvalHook`` should be divisible of that in ``CheckpointHook``.
+            Default: None.
         rule (str | None, optional): Comparison rule for best score. If set to
             None, it will infer a reasonable rule. Keys such as 'acc', 'top'
             .etc will be inferred by 'greater' rule. Keys contain 'loss' will

--- a/mmaction/core/evaluation/eval_hooks.py
+++ b/mmaction/core/evaluation/eval_hooks.py
@@ -338,8 +338,10 @@ class EpochEvalHook(EvalHook):
     """Deprecated class for ``EvalHook``."""
 
     def __init__(self, *args, **kwargs):
-        warnings.warn('"EpochEvalHook" is deprecated, please switch to'
-                      '"EvalHook"')
+        warnings.warn(
+            '"EpochEvalHook" is deprecated, please switch to'
+            '"EvalHook". See https://github.com/open-mmlab/mmaction2/pull/395 for more info'  # noqa: E501
+        )
         super().__init__(*args, **kwargs)
 
 
@@ -347,6 +349,8 @@ class DistEpochEvalHook(DistEvalHook):
     """Deprecated class for ``DistEvalHook``."""
 
     def __init__(self, *args, **kwargs):
-        warnings.warn('"DistEpochEvalHook" is deprecated, please switch to'
-                      '"DistEvalHook"')
+        warnings.warn(
+            '"DistEpochEvalHook" is deprecated, please switch to'
+            '"DistEvalHook". See https://github.com/open-mmlab/mmaction2/pull/395 for more info'  # noqa: E501
+        )
         super().__init__(*args, **kwargs)

--- a/mmaction/core/evaluation/eval_hooks.py
+++ b/mmaction/core/evaluation/eval_hooks.py
@@ -6,8 +6,6 @@ import mmcv
 from mmcv.runner import Hook
 from torch.utils.data import DataLoader
 
-from mmaction.utils import get_root_logger
-
 
 class EvalHook(Hook):
     """Non-Distributed evaluation hook.
@@ -85,8 +83,6 @@ class EvalHook(Hook):
         self.save_best = save_best
         self.eval_kwargs = eval_kwargs
         self.initial_epoch_flag = True
-
-        self.logger = get_root_logger()
 
         if self.save_best is not None:
             self._init_rule(rule, self.save_best)
@@ -208,8 +204,9 @@ class EvalHook(Hook):
             mmcv.symlink(
                 last_ckpt,
                 osp.join(runner.work_dir, f'best_{self.key_indicator}.pth'))
-            self.logger.info(f'Now best checkpoint is {current}.pth.'
-                             f'Best {self.key_indicator} is {best_score:0.4f}')
+            runner.logger.info(
+                f'Now best checkpoint is {current}.pth.'
+                f'Best {self.key_indicator} is {best_score:0.4f}')
 
     def evaluate(self, runner, results):
         """Evaluate the results.

--- a/mmaction/core/evaluation/eval_hooks.py
+++ b/mmaction/core/evaluation/eval_hooks.py
@@ -89,7 +89,7 @@ class EvalHook(Hook):
         assert isinstance(save_best, str) or save_best is None
         self.save_best = save_best
         self.eval_kwargs = eval_kwargs
-        self.initial_epoch_flag = True
+        self.initial_flag = True
 
         if self.save_best is not None:
             self._init_rule(rule, self.save_best)
@@ -132,21 +132,21 @@ class EvalHook(Hook):
         """Evaluate the model only at the start of training by iteration."""
         if self.by_epoch:
             return
-        if not self.initial_epoch_flag:
+        if not self.initial_flag:
             return
         if self.start is not None and runner.iter >= self.start:
             self.after_train_iter(runner)
-        self.initial_epoch_flag = False
+        self.initial_flag = False
 
     def before_train_epoch(self, runner):
         """Evaluate the model only at the start of training by epoch."""
         if not self.by_epoch:
             return
-        if not self.initial_epoch_flag:
+        if not self.initial_flag:
             return
         if self.start is not None and runner.epoch >= self.start:
             self.after_train_epoch(runner)
-        self.initial_epoch_flag = False
+        self.initial_flag = False
 
     def after_train_iter(self, runner):
         """Called after every training iter to evaluate the results."""
@@ -190,7 +190,8 @@ class EvalHook(Hook):
             # No evaluation if start is larger than the current time.
             return False
         else:
-            # Evaluation only at epochs 3, 5, 7... if start==3 and interval==2
+            # Evaluation only at epochs/iters 3, 5, 7...
+            # if start==3 and interval==2
             if (current + 1 - self.start) % self.interval:
                 return False
         return True
@@ -199,7 +200,7 @@ class EvalHook(Hook):
         if self.by_epoch:
             current = f'epoch_{runner.epoch + 1}'
         else:
-            current = f'iter_{runner.epoch + 1}'
+            current = f'iter_{runner.iter + 1}'
 
         best_score = runner.meta['hook_msgs'].get(
             'best_score', self.init_value_map[self.rule])

--- a/mmaction/core/evaluation/eval_hooks.py
+++ b/mmaction/core/evaluation/eval_hooks.py
@@ -252,8 +252,10 @@ class DistEvalHook(EvalHook):
              ``top1_acc``, ``top5_acc``, ``mean_class_accuracy``,
             ``mean_average_precision``, ``mmit_mean_average_precision``
             for action recognition dataset (RawframeDataset and VideoDataset).
-            ``AR@AN``, ``auc`` for action localization dataset.
-            (ActivityNetDataset). Default: None.
+            ``AR@AN``, ``auc`` for action localization dataset
+            (ActivityNetDataset). If ``save_best`` is ``auto``, the first key
+            will be used. The interval of ``CheckpointHook`` should device
+            EvalHook. Default: None.
         rule (str | None, optional): Comparison rule for best score. If set to
             None, it will infer a reasonable rule. Keys such as 'acc', 'top'
             .etc will be inferred by 'greater' rule. Keys contain 'loss' will

--- a/mmaction/datasets/activitynet_dataset.py
+++ b/mmaction/datasets/activitynet_dataset.py
@@ -2,6 +2,7 @@ import copy
 import os
 import os.path as osp
 import warnings
+from collections import OrderedDict
 
 import mmcv
 import numpy as np
@@ -238,7 +239,7 @@ class ActivityNetDataset(BaseDataset):
             if metric not in allowed_metrics:
                 raise KeyError(f'metric {metric} is not supported')
 
-        eval_results = {}
+        eval_results = OrderedDict()
         ground_truth = self._import_ground_truth()
         proposal, num_proposals = self._import_proposals(results)
 

--- a/mmaction/datasets/base.py
+++ b/mmaction/datasets/base.py
@@ -2,7 +2,7 @@ import copy
 import os.path as osp
 import warnings
 from abc import ABCMeta, abstractmethod
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 
 import mmcv
 import numpy as np
@@ -170,7 +170,7 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
             if metric not in allowed_metrics:
                 raise KeyError(f'metric {metric} is not supported')
 
-        eval_results = {}
+        eval_results = OrderedDict()
         gt_labels = [ann['label'] for ann in self.video_infos]
 
         for metric in metrics:

--- a/mmaction/datasets/hvu_dataset.py
+++ b/mmaction/datasets/hvu_dataset.py
@@ -1,5 +1,6 @@
 import copy
 import os.path as osp
+from collections import OrderedDict
 
 import mmcv
 import numpy as np
@@ -164,7 +165,8 @@ class HVUDataset(BaseDataset):
 
         gt_labels = [ann['label'] for ann in self.video_infos]
 
-        eval_results = {}
+        eval_results = OrderedDict()
+
         for category in self.tag_categories:
 
             start_idx = self.category2startidx[category]

--- a/mmaction/datasets/ssn_dataset.py
+++ b/mmaction/datasets/ssn_dataset.py
@@ -1,6 +1,7 @@
 import copy
 import os.path as osp
 import warnings
+from collections import OrderedDict
 
 import mmcv
 import numpy as np
@@ -470,7 +471,7 @@ class SSNDataset(BaseDataset):
                                        for x in dets.tolist()])
             plain_detections[class_idx] = detection_list
 
-        eval_results = {}
+        eval_results = OrderedDict()
         for metric in metrics:
             if metric == 'mAP':
                 eval_dataset = metric_options.setdefault('mAP', {}).setdefault(

--- a/tests/test_runtime/test_eval_hook.py
+++ b/tests/test_runtime/test_eval_hook.py
@@ -139,7 +139,7 @@ def test_eval_hook():
             runner.run([loader], [('train', 1)], 8)
 
             real_path = osp.join(tmpdir, 'epoch_4.pth')
-            link_path = osp.join(tmpdir, 'best_acc.pth')
+            link_path = osp.join(tmpdir, 'best_acc_epoch_4.pth')
 
             assert runner.meta['hook_msgs']['best_ckpt'] == osp.realpath(
                 real_path)
@@ -161,7 +161,7 @@ def test_eval_hook():
             runner.run([loader], [('train', 1)], 8)
 
             real_path = osp.join(tmpdir, 'epoch_4.pth')
-            link_path = osp.join(tmpdir, 'best_acc.pth')
+            link_path = osp.join(tmpdir, 'best_acc_epoch_4.pth')
 
             assert runner.meta['hook_msgs']['best_ckpt'] == osp.realpath(
                 real_path)
@@ -181,7 +181,7 @@ def test_eval_hook():
             runner.run([loader], [('train', 1)], 8)
 
             real_path = osp.join(tmpdir, 'epoch_4.pth')
-            link_path = osp.join(tmpdir, 'best_score.pth')
+            link_path = osp.join(tmpdir, 'best_score_epoch_4.pth')
 
             assert runner.meta['hook_msgs']['best_ckpt'] == osp.realpath(
                 real_path)
@@ -201,7 +201,7 @@ def test_eval_hook():
             runner.run([loader], [('train', 1)], 8)
 
             real_path = osp.join(tmpdir, 'epoch_6.pth')
-            link_path = osp.join(tmpdir, 'best_acc.pth')
+            link_path = osp.join(tmpdir, 'best_acc_epoch_6.pth')
 
             assert runner.meta['hook_msgs']['best_ckpt'] == osp.realpath(
                 real_path)
@@ -220,7 +220,7 @@ def test_eval_hook():
             runner.run([loader], [('train', 1)], 2)
 
             real_path = osp.join(tmpdir, 'epoch_2.pth')
-            link_path = osp.join(tmpdir, 'best_acc.pth')
+            link_path = osp.join(tmpdir, 'best_acc_epoch_2.pth')
 
             assert runner.meta['hook_msgs']['best_ckpt'] == osp.realpath(
                 real_path)
@@ -238,7 +238,7 @@ def test_eval_hook():
             runner.run([loader], [('train', 1)], 8)
 
             real_path = osp.join(tmpdir, 'epoch_4.pth')
-            link_path = osp.join(tmpdir, 'best_acc.pth')
+            link_path = osp.join(tmpdir, 'best_acc_epoch_4.pth')
 
             assert runner.meta['hook_msgs']['best_ckpt'] == osp.realpath(
                 real_path)

--- a/tests/test_runtime/test_eval_hook.py
+++ b/tests/test_runtime/test_eval_hook.py
@@ -138,12 +138,11 @@ def test_eval_hook():
             runner.register_hook(eval_hook)
             runner.run([loader], [('train', 1)], 8)
 
-            real_path = osp.join(tmpdir, 'epoch_4.pth')
-            link_path = osp.join(tmpdir, 'best_acc_epoch_4.pth')
+            ckpt_path = osp.join(tmpdir, 'best_acc_epoch_4.pth')
 
             assert runner.meta['hook_msgs']['best_ckpt'] == osp.realpath(
-                real_path)
-            assert osp.exists(link_path)
+                ckpt_path)
+            assert osp.exists(ckpt_path)
             assert runner.meta['hook_msgs']['best_score'] == 7
 
         # total_epochs = 8, return the best acc and corresponding epoch
@@ -160,12 +159,11 @@ def test_eval_hook():
             runner.register_hook(eval_hook)
             runner.run([loader], [('train', 1)], 8)
 
-            real_path = osp.join(tmpdir, 'epoch_4.pth')
-            link_path = osp.join(tmpdir, 'best_acc_epoch_4.pth')
+            ckpt_path = osp.join(tmpdir, 'best_acc_epoch_4.pth')
 
             assert runner.meta['hook_msgs']['best_ckpt'] == osp.realpath(
-                real_path)
-            assert osp.exists(link_path)
+                ckpt_path)
+            assert osp.exists(ckpt_path)
             assert runner.meta['hook_msgs']['best_score'] == 7
 
         # total_epochs = 8, return the best score and corresponding epoch
@@ -180,12 +178,11 @@ def test_eval_hook():
             runner.register_hook(eval_hook)
             runner.run([loader], [('train', 1)], 8)
 
-            real_path = osp.join(tmpdir, 'epoch_4.pth')
-            link_path = osp.join(tmpdir, 'best_score_epoch_4.pth')
+            ckpt_path = osp.join(tmpdir, 'best_score_epoch_4.pth')
 
             assert runner.meta['hook_msgs']['best_ckpt'] == osp.realpath(
-                real_path)
-            assert osp.exists(link_path)
+                ckpt_path)
+            assert osp.exists(ckpt_path)
             assert runner.meta['hook_msgs']['best_score'] == 7
 
         # total_epochs = 8, return the best score using less compare func
@@ -200,12 +197,11 @@ def test_eval_hook():
             runner.register_hook(eval_hook)
             runner.run([loader], [('train', 1)], 8)
 
-            real_path = osp.join(tmpdir, 'epoch_6.pth')
-            link_path = osp.join(tmpdir, 'best_acc_epoch_6.pth')
+            ckpt_path = osp.join(tmpdir, 'best_acc_epoch_6.pth')
 
             assert runner.meta['hook_msgs']['best_ckpt'] == osp.realpath(
-                real_path)
-            assert osp.exists(link_path)
+                ckpt_path)
+            assert osp.exists(ckpt_path)
             assert runner.meta['hook_msgs']['best_score'] == -3
 
         # Test the EvalHook when resume happend
@@ -219,12 +215,11 @@ def test_eval_hook():
             runner.register_hook(eval_hook)
             runner.run([loader], [('train', 1)], 2)
 
-            real_path = osp.join(tmpdir, 'epoch_2.pth')
-            link_path = osp.join(tmpdir, 'best_acc_epoch_2.pth')
+            ckpt_path = osp.join(tmpdir, 'best_acc_epoch_2.pth')
 
             assert runner.meta['hook_msgs']['best_ckpt'] == osp.realpath(
-                real_path)
-            assert osp.exists(link_path)
+                ckpt_path)
+            assert osp.exists(ckpt_path)
             assert runner.meta['hook_msgs']['best_score'] == 4
 
             resume_from = osp.join(tmpdir, 'latest.pth')
@@ -237,12 +232,11 @@ def test_eval_hook():
             runner.resume(resume_from)
             runner.run([loader], [('train', 1)], 8)
 
-            real_path = osp.join(tmpdir, 'epoch_4.pth')
-            link_path = osp.join(tmpdir, 'best_acc_epoch_4.pth')
+            ckpt_path = osp.join(tmpdir, 'best_acc_epoch_4.pth')
 
             assert runner.meta['hook_msgs']['best_ckpt'] == osp.realpath(
-                real_path)
-            assert osp.exists(link_path)
+                ckpt_path)
+            assert osp.exists(ckpt_path)
             assert runner.meta['hook_msgs']['best_score'] == 7
 
 

--- a/tests/test_runtime/test_train.py
+++ b/tests/test_runtime/test_train.py
@@ -1,5 +1,6 @@
 import copy
 import tempfile
+from collections import OrderedDict
 
 import pytest
 import torch
@@ -18,7 +19,7 @@ class ExampleDataset(Dataset):
         self.test_mode = test_mode
 
     def evaluate(self, results, logger=None):
-        eval_results = dict()
+        eval_results = OrderedDict()
         eval_results['acc'] = 1
         return eval_results
 

--- a/tools/analysis/eval_metric.py
+++ b/tools/analysis/eval_metric.py
@@ -53,7 +53,8 @@ def main():
     eval_kwargs = cfg.get('evaluation', {}).copy()
     # hard-code way to remove EvalHook args
     for key in [
-            'interval', 'tmpdir', 'start', 'gpu_collect', 'save_best', 'rule'
+            'interval', 'tmpdir', 'start', 'gpu_collect', 'save_best', 'rule',
+            'by_epoch'
     ]:
         eval_kwargs.pop(key, None)
     eval_kwargs.update(dict(metrics=args.eval, **kwargs))

--- a/tools/analysis/eval_metric.py
+++ b/tools/analysis/eval_metric.py
@@ -51,7 +51,7 @@ def main():
 
     kwargs = {} if args.eval_options is None else args.eval_options
     eval_kwargs = cfg.get('evaluation', {}).copy()
-    # hard-code way to remove EpochEvalHook args
+    # hard-code way to remove EvalHook args
     for key in [
             'interval', 'tmpdir', 'start', 'gpu_collect', 'save_best', 'rule'
     ]:

--- a/tools/analysis/eval_metric.py
+++ b/tools/analysis/eval_metric.py
@@ -53,8 +53,7 @@ def main():
     eval_kwargs = cfg.get('evaluation', {}).copy()
     # hard-code way to remove EpochEvalHook args
     for key in [
-            'interval', 'tmpdir', 'start', 'gpu_collect', 'save_best', 'rule',
-            'key_indicator'
+            'interval', 'tmpdir', 'start', 'gpu_collect', 'save_best', 'rule'
     ]:
         eval_kwargs.pop(key, None)
     eval_kwargs.update(dict(metrics=args.eval, **kwargs))


### PR DESCRIPTION
## OverView

This PR refactors EvalHook

1. Add by_epoch param to determine perform evaluation by epoch or by iteration.
2. Add automatically assign a compare key when users do not set one.
3. Save checkpoint by creating a symlink as well as record best info in runner hook meta
4. Refactor the code structure

## Migration

Configs files need to be changed

1. Rename `EpochEvalHook` to `EvalHook`, `DistEpochEvalHook` to `DistEvalHook`.
2. Rename `key_indicator` to `save_best`.

For example, in `slowfast_kinetics_pretrained_r50_4x16x1_20e_ava_rgb.py` cfg file

from 

```python
evaluation = dict(interval=1, key_indicator='mAP@0.5IOU')
```

to

```python
evaluation = dict(interval=1, save_best='mAP@0.5IOU')
```

## Misc.
This Part may further be merged into `MMCV` or applied to other MM codebases.