### PR TITLE
Fix dummy forward

### DIFF
--- a/mmaction/models/recognizers/recognizer2d.py
+++ b/mmaction/models/recognizers/recognizer2d.py
@@ -91,6 +91,16 @@ class Recognizer2D(BaseRecognizer):
         num_segs = imgs.shape[0] // batches
 
         x = self.extract_feat(imgs)
+        if hasattr(self, 'neck'):
+            x = [
+                each.reshape((-1, num_segs) +
+                             each.shape[1:]).transpose(1, 2).contiguous()
+                for each in x
+            ]
+            x, _ = self.neck(x)
+            x = x.squeeze(2)
+            num_segs = 1
+
         outs = (self.cls_head(x, num_segs), )
         return outs
 

--- a/mmaction/models/recognizers/recognizer3d.py
+++ b/mmaction/models/recognizers/recognizer3d.py
@@ -55,8 +55,11 @@ class Recognizer3D(BaseRecognizer):
             Tensor: Class score.
         """
         imgs = imgs.reshape((-1, ) + imgs.shape[2:])
-
         x = self.extract_feat(imgs)
+
+        if hasattr(self, 'neck'):
+            x, _ = self.neck(x)
+
         outs = (self.cls_head(x), )
         return outs
 

--- a/tests/test_models/test_recognizers.py
+++ b/tests/test_models/test_recognizers.py
@@ -389,6 +389,14 @@ def test_tpn():
         for one_img in img_list:
             recognizer(one_img, None, return_loss=False)
 
+    # Test forward dummy
+    with torch.no_grad():
+        img_list = [img[None, :] for img in imgs]
+        if hasattr(model, 'forward_dummy'):
+            model.forward = model.forward_dummy
+        for one_img in img_list:
+            recognizer(one_img, None, return_loss=False)
+
     # Test forward gradcam
     recognizer(imgs, gradcam=True)
     for one_img in img_list:
@@ -413,6 +421,14 @@ def test_tpn():
     # Test forward test
     with torch.no_grad():
         img_list = [img[None, :] for img in imgs]
+        for one_img in img_list:
+            recognizer(one_img, None, return_loss=False)
+
+    # Test dummy forward
+    with torch.no_grad():
+        img_list = [img[None, :] for img in imgs]
+        if hasattr(model, 'forward_dummy'):
+            model.forward = model.forward_dummy
         for one_img in img_list:
             recognizer(one_img, None, return_loss=False)
 


### PR DESCRIPTION
This PR fixes a bug when calling `dummy forward`(FLOPS calculation or onnx conversion), which used to skip the neck module.
Fixes #429 