### PR TITLE
data_preprocess

### DIFF
--- a/tools/data/activitynet/download_videos.sh
+++ b/tools/data/activitynet/download_videos.sh
@@ -4,6 +4,7 @@
 conda env create -f environment.yml
 source activate activitynet
 pip install --upgrade youtube-dl
+pip install mmcv
 
 DATA_DIR="../../../data/ActivityNet"
 python download.py

--- a/tools/data/gym/environment.yml
+++ b/tools/data/gym/environment.yml
@@ -1,4 +1,4 @@
-name: kinetics
+name: gym
 channels:
   - anaconda
   - menpo


### PR DESCRIPTION
fix some errors in download_video.sh
for activitynet, download.py relies on mmcv.
for gym, the virtual env name should be gym.