### PR TITLE
[Fix] Fix potential bug about output_config overwrite

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,12 +13,13 @@
 - Support training and testing for Spatio-Temporal Action Detection ([#351](https://github.com/open-mmlab/mmaction2/pull/351))
 - Fix CI due to pip upgrade ([#454](https://github.com/open-mmlab/mmaction2/pull/454))
 - Add markdown lint in pre-commit hook ([#255](https://github.com/open-mmlab/mmaction2/pull/225))
-- Use title case in modelzoo statistics. ([#456](https://github.com/open-mmlab/mmaction2/pull/456))
+- Use title case in modelzoo statistics ([#456](https://github.com/open-mmlab/mmaction2/pull/456))
 - Add FAQ documents for easy troubleshooting. ([#413](https://github.com/open-mmlab/mmaction2/pull/413), [#420](https://github.com/open-mmlab/mmaction2/pull/420), [#439](https://github.com/open-mmlab/mmaction2/pull/439))
 
 **Bug and Typo Fixes**
 
-- Fix typo in default argument of BaseHead. ([#446](https://github.com/open-mmlab/mmaction2/pull/446))
+- Fix typo in default argument of BaseHead ([#446](https://github.com/open-mmlab/mmaction2/pull/446))
+- Fix potential bug about `output_config` overwrite ([#463](https://github.com/open-mmlab/mmaction2/pull/463))
 
 **ModelZoo**
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -102,15 +102,18 @@ def main():
 
     # Load output_config from cfg
     output_config = cfg.get('output_config', {})
-    # Overwrite output_config from args.out
-    output_config = Config._merge_a_into_b(dict(out=args.out), output_config)
+    if args.out:
+        # Overwrite output_config from args.out
+        output_config = Config._merge_a_into_b(dict(out=args.out), output_config)
 
     # Load eval_config from cfg
     eval_config = cfg.get('eval_config', {})
-    # Overwrite eval_config from args.eval
-    eval_config = Config._merge_a_into_b(dict(metrics=args.eval), eval_config)
-    # Add options from args.eval_options
-    eval_config = Config._merge_a_into_b(args.eval_options, eval_config)
+    if args.eval:
+        # Overwrite eval_config from args.eval
+        eval_config = Config._merge_a_into_b(dict(metrics=args.eval), eval_config)
+    if args.eval_options:
+        # Add options from args.eval_options
+        eval_config = Config._merge_a_into_b(args.eval_options, eval_config)
 
     assert output_config or eval_config, \
         ('Please specify at least one operation (save or eval the '

--- a/tools/test.py
+++ b/tools/test.py
@@ -104,13 +104,15 @@ def main():
     output_config = cfg.get('output_config', {})
     if args.out:
         # Overwrite output_config from args.out
-        output_config = Config._merge_a_into_b(dict(out=args.out), output_config)
+        output_config = Config._merge_a_into_b(
+            dict(out=args.out), output_config)
 
     # Load eval_config from cfg
     eval_config = cfg.get('eval_config', {})
     if args.eval:
         # Overwrite eval_config from args.eval
-        eval_config = Config._merge_a_into_b(dict(metrics=args.eval), eval_config)
+        eval_config = Config._merge_a_into_b(
+            dict(metrics=args.eval), eval_config)
     if args.eval_options:
         # Add options from args.eval_options
         eval_config = Config._merge_a_into_b(args.eval_options, eval_config)


### PR DESCRIPTION
This PR fixes potential bug when users do not assign parser args. For example, if a user does not assign `args.out` 

```python
output_config = dict(out=f'{work_dir}/results.json', output_format='json')
args.out = None
output_config = Config._merge_a_into_b(dict(out=args.out), output_config)
```
then, `output_config` in config files will be overwritten.