### PR TITLE
[Improvement] save best ckpt during training

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,7 @@
 - Add markdown lint in pre-commit hook ([#255](https://github.com/open-mmlab/mmaction2/pull/225))
 - Use title case in modelzoo statistics. ([#456](https://github.com/open-mmlab/mmaction2/pull/456))
 - Add FAQ documents for easy troubleshooting. ([#413](https://github.com/open-mmlab/mmaction2/pull/413), [#420](https://github.com/open-mmlab/mmaction2/pull/420), [#439](https://github.com/open-mmlab/mmaction2/pull/439))
+- Save best checkpoint during training. ([#464](https://github.com/open-mmlab/mmaction2/pull/464))
 
 **Bug and Typo Fixes**
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,13 +13,14 @@
 - Support training and testing for Spatio-Temporal Action Detection ([#351](https://github.com/open-mmlab/mmaction2/pull/351))
 - Fix CI due to pip upgrade ([#454](https://github.com/open-mmlab/mmaction2/pull/454))
 - Add markdown lint in pre-commit hook ([#255](https://github.com/open-mmlab/mmaction2/pull/225))
-- Use title case in modelzoo statistics. ([#456](https://github.com/open-mmlab/mmaction2/pull/456))
+- Use title case in modelzoo statistics ([#456](https://github.com/open-mmlab/mmaction2/pull/456))
 - Add FAQ documents for easy troubleshooting. ([#413](https://github.com/open-mmlab/mmaction2/pull/413), [#420](https://github.com/open-mmlab/mmaction2/pull/420), [#439](https://github.com/open-mmlab/mmaction2/pull/439))
 - Save best checkpoint during training. ([#464](https://github.com/open-mmlab/mmaction2/pull/464))
 
 **Bug and Typo Fixes**
 
-- Fix typo in default argument of BaseHead. ([#446](https://github.com/open-mmlab/mmaction2/pull/446))
+- Fix typo in default argument of BaseHead ([#446](https://github.com/open-mmlab/mmaction2/pull/446))
+- Fix potential bug about `output_config` overwrite ([#463](https://github.com/open-mmlab/mmaction2/pull/463))
 
 **ModelZoo**
 

--- a/mmaction/core/evaluation/eval_hooks.py
+++ b/mmaction/core/evaluation/eval_hooks.py
@@ -148,10 +148,7 @@ class EpochEvalHook(Hook):
             self.best_json['key_indicator'] = self.key_indicator
             mmcv.dump(self.best_json, json_path)
             if self.best_ckpt_name:
-                best_ckpt_path = osp.join(runner.work_dir, self.best_ckpt_name)
-                if osp.isfile(best_ckpt_path):
-                    os.remove(best_ckpt_path)
-                shutil.copyfile(current_ckpt_path, best_ckpt_path)
+                runner.save_checkpoint(runner.work_dir, self.best_ckpt_name)
 
     def after_train_epoch(self, runner):
         """Called after every training epoch to evaluate the results."""

--- a/mmaction/core/evaluation/eval_hooks.py
+++ b/mmaction/core/evaluation/eval_hooks.py
@@ -171,8 +171,7 @@ class EpochEvalHook(Hook):
         from mmaction.apis import single_gpu_test
         results = single_gpu_test(runner.model, self.dataloader)
         key_score = self.evaluate(runner, results)
-        self._do_save_best(self, key_score, json_path, current_ckpt_path,
-                           runner)
+        self._do_save_best(key_score, json_path, current_ckpt_path, runner)
 
     def evaluate(self, runner, results):
         """Evaluate the results.
@@ -285,5 +284,4 @@ class DistEpochEvalHook(EpochEvalHook):
         if runner.rank == 0:
             print('\n')
             key_score = self.evaluate(runner, results)
-            self._do_save_best(self, key_score, json_path, current_ckpt_path,
-                               runner)
+            self._do_save_best(key_score, json_path, current_ckpt_path, runner)

--- a/mmaction/core/evaluation/eval_hooks.py
+++ b/mmaction/core/evaluation/eval_hooks.py
@@ -148,8 +148,8 @@ class EpochEvalHook(Hook):
             self.best_json['key_indicator'] = self.key_indicator
             mmcv.dump(self.best_json, json_path)
             if self.best_ckpt_name:
-                best_ckpt_path = osp(runner.work_dir, self.best_ckpt_name)
-                if os.path.isfile(best_ckpt_path):
+                best_ckpt_path = osp.join(runner.work_dir, self.best_ckpt_name)
+                if osp.isfile(best_ckpt_path):
                     os.remove(best_ckpt_path)
                 shutil.copyfile(current_ckpt_path, best_ckpt_path)
 

--- a/mmaction/models/builder.py
+++ b/mmaction/models/builder.py
@@ -13,7 +13,7 @@ except (ImportError, ModuleNotFoundError):
     # Define an empty registry and building func, so that can import
     DETECTORS = Registry('detector')
 
-    def bulid_detector(cfg, train_cfg, test_cfg):
+    def build_detector(cfg, train_cfg, test_cfg):
         pass
 
 

--- a/mmaction/models/heads/roi_head.py
+++ b/mmaction/models/heads/roi_head.py
@@ -85,5 +85,5 @@ if 'mmdet' in dir():
             return det_bboxes, det_labels
 else:
     # Just define an empty class, so that __init__ can import it.
-    class AVARoIHead(StandardRoIHead):
+    class AVARoIHead:
         pass

--- a/mmaction/models/roi_extractors/single_straight3d.py
+++ b/mmaction/models/roi_extractors/single_straight3d.py
@@ -2,7 +2,11 @@ import warnings
 
 import torch
 import torch.nn as nn
-from mmcv.ops import RoIAlign, RoIPool
+
+try:
+    from mmcv.ops import RoIAlign, RoIPool
+except (ImportError, ModuleNotFoundError):
+    warnings.warn('Please install mmcv-full to use RoIAlign and RoIPool')
 
 try:
     import mmdet  # noqa

--- a/tests/test_runtime/test_eval_hook.py
+++ b/tests/test_runtime/test_eval_hook.py
@@ -271,7 +271,7 @@ def test_eval_hook():
         resume_from = osp.join(tmpdir, 'latest.pth')
         loader = DataLoader(ExampleDataset(), batch_size=1)
         eval_hook = EpochEvalHook(
-            data_loader, key_indicator='acc', best_ckpt_name='best.pth')
+            data_loader, key_indicator='acc', save_best_ckpt=True)
         runner = EpochBasedRunner(
             model=model,
             batch_processor=None,
@@ -286,13 +286,11 @@ def test_eval_hook():
         best_json_path = osp.join(tmpdir, 'best.json')
         best_json = mmcv.load(best_json_path)
         real_path = osp.join(tmpdir, 'epoch_4.pth')
-        best_ckpt_path = osp.join(tmpdir, 'best.pth')
 
         assert best_json['best_ckpt'] == osp.realpath(real_path)
         assert best_json['best_score'] == 7
         assert best_json['key_indicator'] == 'acc'
-        import os
-        assert os.path.isfile(best_ckpt_path)
+        assert osp.isfile(osp.join(tmpdir, 'best_7.0000_4.pth'))
 
 
 @patch('mmaction.apis.single_gpu_test', MagicMock)

--- a/tests/test_runtime/test_eval_hook.py
+++ b/tests/test_runtime/test_eval_hook.py
@@ -247,8 +247,8 @@ def test_eval_hook():
         assert best_json['key_indicator'] == 'acc'
 
     data_loader = DataLoader(EvalDataset(), batch_size=1)
-    eval_hook = EpochEvalHook(data_loader, key_indicator='acc')
     with tempfile.TemporaryDirectory() as tmpdir:
+        eval_hook = EpochEvalHook(data_loader, key_indicator='acc')
         logger = get_logger('test_eval')
         runner = EpochBasedRunner(
             model=model,
@@ -270,7 +270,8 @@ def test_eval_hook():
 
         resume_from = osp.join(tmpdir, 'latest.pth')
         loader = DataLoader(ExampleDataset(), batch_size=1)
-        eval_hook = EpochEvalHook(data_loader, key_indicator='acc')
+        eval_hook = EpochEvalHook(
+            data_loader, key_indicator='acc', best_ckpt_name='best.pth')
         runner = EpochBasedRunner(
             model=model,
             batch_processor=None,
@@ -285,10 +286,13 @@ def test_eval_hook():
         best_json_path = osp.join(tmpdir, 'best.json')
         best_json = mmcv.load(best_json_path)
         real_path = osp.join(tmpdir, 'epoch_4.pth')
+        best_ckpt_path = osp.join(tmpdir, 'best.pth')
 
         assert best_json['best_ckpt'] == osp.realpath(real_path)
         assert best_json['best_score'] == 7
         assert best_json['key_indicator'] == 'acc'
+        import os
+        assert os.path.isfile(best_ckpt_path)
 
 
 @patch('mmaction.apis.single_gpu_test', MagicMock)

--- a/tools/data/activitynet/download_videos.sh
+++ b/tools/data/activitynet/download_videos.sh
@@ -4,6 +4,7 @@
 conda env create -f environment.yml
 source activate activitynet
 pip install --upgrade youtube-dl
+pip install mmcv
 
 DATA_DIR="../../../data/ActivityNet"
 python download.py

--- a/tools/data/gym/environment.yml
+++ b/tools/data/gym/environment.yml
@@ -1,4 +1,4 @@
-name: kinetics
+name: gym
 channels:
   - anaconda
   - menpo

--- a/tools/test.py
+++ b/tools/test.py
@@ -102,15 +102,20 @@ def main():
 
     # Load output_config from cfg
     output_config = cfg.get('output_config', {})
-    # Overwrite output_config from args.out
-    output_config = Config._merge_a_into_b(dict(out=args.out), output_config)
+    if args.out:
+        # Overwrite output_config from args.out
+        output_config = Config._merge_a_into_b(
+            dict(out=args.out), output_config)
 
     # Load eval_config from cfg
     eval_config = cfg.get('eval_config', {})
-    # Overwrite eval_config from args.eval
-    eval_config = Config._merge_a_into_b(dict(metrics=args.eval), eval_config)
-    # Add options from args.eval_options
-    eval_config = Config._merge_a_into_b(args.eval_options, eval_config)
+    if args.eval:
+        # Overwrite eval_config from args.eval
+        eval_config = Config._merge_a_into_b(
+            dict(metrics=args.eval), eval_config)
+    if args.eval_options:
+        # Add options from args.eval_options
+        eval_config = Config._merge_a_into_b(args.eval_options, eval_config)
 
     assert output_config or eval_config, \
         ('Please specify at least one operation (save or eval the '


### PR DESCRIPTION
Fix #460 

Add arg `save_best_ckpt` for eval hook,. If set to True, then save best ckpt in `work_dir` with name `best_{best_socre}_{epoch_id}.pth`

+ [x] modify eval hook
+ [x] add unittest
+ [x] add changelog
+ [ ] fix codecov