### PR TITLE
[Fix] fix a bug about validation of ava dataset

### DIFF
--- a/configs/detection/ava/slowfast_context_kinetics_pretrained_r50_4x16x1_20e_ava_rgb.py
+++ b/configs/detection/ava/slowfast_context_kinetics_pretrained_r50_4x16x1_20e_ava_rgb.py
@@ -159,12 +159,7 @@ lr_config = dict(
 total_epochs = 20
 checkpoint_config = dict(interval=1)
 workflow = [('train', 1)]
-# Three avaiable key indicators for ava dataset
-# 'Recall@0.5@100' 'AR@100' 'PascalBoxes_Precision/mAP@0.5IOU'
-evaluation = dict(
-    interval=1,
-    key_indicator='PascalBoxes_Precision/mAP@0.5IOU',
-    rule='greater')
+evaluation = dict(interval=1, key_indicator='mAP@0.5IOU')
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/configs/detection/ava/slowfast_context_kinetics_pretrained_r50_4x16x1_20e_ava_rgb.py
+++ b/configs/detection/ava/slowfast_context_kinetics_pretrained_r50_4x16x1_20e_ava_rgb.py
@@ -159,7 +159,12 @@ lr_config = dict(
 total_epochs = 20
 checkpoint_config = dict(interval=1)
 workflow = [('train', 1)]
-evaluation = dict(interval=1)
+# Three avaiable key indicators for ava dataset
+# 'Recall@0.5@100' 'AR@100' 'PascalBoxes_Precision/mAP@0.5IOU'
+evaluation = dict(
+    interval=1,
+    key_indicator='PascalBoxes_Precision/mAP@0.5IOU',
+    rule='greater')
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/configs/detection/ava/slowfast_kinetics_pretrained_r50_4x16x1_20e_ava_rgb.py
+++ b/configs/detection/ava/slowfast_kinetics_pretrained_r50_4x16x1_20e_ava_rgb.py
@@ -158,7 +158,12 @@ lr_config = dict(
 total_epochs = 20
 checkpoint_config = dict(interval=1)
 workflow = [('train', 1)]
-evaluation = dict(interval=1)
+# Three avaiable key indicators for ava dataset
+# 'Recall@0.5@100' 'AR@100' 'PascalBoxes_Precision/mAP@0.5IOU'
+evaluation = dict(
+    interval=1,
+    key_indicator='PascalBoxes_Precision/mAP@0.5IOU',
+    rule='greater')
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/configs/detection/ava/slowfast_kinetics_pretrained_r50_4x16x1_20e_ava_rgb.py
+++ b/configs/detection/ava/slowfast_kinetics_pretrained_r50_4x16x1_20e_ava_rgb.py
@@ -158,12 +158,7 @@ lr_config = dict(
 total_epochs = 20
 checkpoint_config = dict(interval=1)
 workflow = [('train', 1)]
-# Three avaiable key indicators for ava dataset
-# 'Recall@0.5@100' 'AR@100' 'PascalBoxes_Precision/mAP@0.5IOU'
-evaluation = dict(
-    interval=1,
-    key_indicator='PascalBoxes_Precision/mAP@0.5IOU',
-    rule='greater')
+evaluation = dict(interval=1, key_indicator='mAP@0.5IOU')
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/configs/detection/ava/slowfast_kinetics_pretrained_r50_8x8x1_20e_ava_rgb.py
+++ b/configs/detection/ava/slowfast_kinetics_pretrained_r50_8x8x1_20e_ava_rgb.py
@@ -158,7 +158,12 @@ lr_config = dict(
 total_epochs = 20
 checkpoint_config = dict(interval=1)
 workflow = [('train', 1)]
-evaluation = dict(interval=1)
+# Three avaiable key indicators for ava dataset
+# 'Recall@0.5@100' 'AR@100' 'PascalBoxes_Precision/mAP@0.5IOU'
+evaluation = dict(
+    interval=1,
+    key_indicator='PascalBoxes_Precision/mAP@0.5IOU',
+    rule='greater')
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/configs/detection/ava/slowfast_kinetics_pretrained_r50_8x8x1_20e_ava_rgb.py
+++ b/configs/detection/ava/slowfast_kinetics_pretrained_r50_8x8x1_20e_ava_rgb.py
@@ -158,12 +158,7 @@ lr_config = dict(
 total_epochs = 20
 checkpoint_config = dict(interval=1)
 workflow = [('train', 1)]
-# Three avaiable key indicators for ava dataset
-# 'Recall@0.5@100' 'AR@100' 'PascalBoxes_Precision/mAP@0.5IOU'
-evaluation = dict(
-    interval=1,
-    key_indicator='PascalBoxes_Precision/mAP@0.5IOU',
-    rule='greater')
+evaluation = dict(interval=1, key_indicator='mAP@0.5IOU')
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/configs/detection/ava/slowonly_kinetics_pretrained_r101_8x8x1_20e_ava_rgb.py
+++ b/configs/detection/ava/slowonly_kinetics_pretrained_r101_8x8x1_20e_ava_rgb.py
@@ -143,7 +143,12 @@ lr_config = dict(
 total_epochs = 20
 checkpoint_config = dict(interval=1)
 workflow = [('train', 1)]
-evaluation = dict(interval=1)
+# Three avaiable key indicators for ava dataset
+# 'Recall@0.5@100' 'AR@100' 'PascalBoxes_Precision/mAP@0.5IOU'
+evaluation = dict(
+    interval=1,
+    key_indicator='PascalBoxes_Precision/mAP@0.5IOU',
+    rule='greater')
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/configs/detection/ava/slowonly_kinetics_pretrained_r101_8x8x1_20e_ava_rgb.py
+++ b/configs/detection/ava/slowonly_kinetics_pretrained_r101_8x8x1_20e_ava_rgb.py
@@ -143,12 +143,7 @@ lr_config = dict(
 total_epochs = 20
 checkpoint_config = dict(interval=1)
 workflow = [('train', 1)]
-# Three avaiable key indicators for ava dataset
-# 'Recall@0.5@100' 'AR@100' 'PascalBoxes_Precision/mAP@0.5IOU'
-evaluation = dict(
-    interval=1,
-    key_indicator='PascalBoxes_Precision/mAP@0.5IOU',
-    rule='greater')
+evaluation = dict(interval=1, key_indicator='mAP@0.5IOU')
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/configs/detection/ava/slowonly_kinetics_pretrained_r50_4x16x1_20e_ava_rgb.py
+++ b/configs/detection/ava/slowonly_kinetics_pretrained_r50_4x16x1_20e_ava_rgb.py
@@ -142,7 +142,12 @@ lr_config = dict(
 total_epochs = 20
 checkpoint_config = dict(interval=1)
 workflow = [('train', 1)]
-evaluation = dict(interval=1)
+# Three avaiable key indicators for ava dataset
+# 'Recall@0.5@100' 'AR@100' 'PascalBoxes_Precision/mAP@0.5IOU'
+evaluation = dict(
+    interval=1,
+    key_indicator='PascalBoxes_Precision/mAP@0.5IOU',
+    rule='greater')
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/configs/detection/ava/slowonly_kinetics_pretrained_r50_4x16x1_20e_ava_rgb.py
+++ b/configs/detection/ava/slowonly_kinetics_pretrained_r50_4x16x1_20e_ava_rgb.py
@@ -142,12 +142,7 @@ lr_config = dict(
 total_epochs = 20
 checkpoint_config = dict(interval=1)
 workflow = [('train', 1)]
-# Three avaiable key indicators for ava dataset
-# 'Recall@0.5@100' 'AR@100' 'PascalBoxes_Precision/mAP@0.5IOU'
-evaluation = dict(
-    interval=1,
-    key_indicator='PascalBoxes_Precision/mAP@0.5IOU',
-    rule='greater')
+evaluation = dict(interval=1, key_indicator='mAP@0.5IOU')
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/configs/detection/ava/slowonly_omnisource_pretrained_r101_8x8x1_20e_ava_rgb.py
+++ b/configs/detection/ava/slowonly_omnisource_pretrained_r101_8x8x1_20e_ava_rgb.py
@@ -142,7 +142,12 @@ lr_config = dict(
 total_epochs = 20
 checkpoint_config = dict(interval=1)
 workflow = [('train', 1)]
-evaluation = dict(interval=1)
+# Three avaiable key indicators for ava dataset
+# 'Recall@0.5@100' 'AR@100' 'PascalBoxes_Precision/mAP@0.5IOU'
+evaluation = dict(
+    interval=1,
+    key_indicator='PascalBoxes_Precision/mAP@0.5IOU',
+    rule='greater')
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/configs/detection/ava/slowonly_omnisource_pretrained_r101_8x8x1_20e_ava_rgb.py
+++ b/configs/detection/ava/slowonly_omnisource_pretrained_r101_8x8x1_20e_ava_rgb.py
@@ -142,12 +142,7 @@ lr_config = dict(
 total_epochs = 20
 checkpoint_config = dict(interval=1)
 workflow = [('train', 1)]
-# Three avaiable key indicators for ava dataset
-# 'Recall@0.5@100' 'AR@100' 'PascalBoxes_Precision/mAP@0.5IOU'
-evaluation = dict(
-    interval=1,
-    key_indicator='PascalBoxes_Precision/mAP@0.5IOU',
-    rule='greater')
+evaluation = dict(interval=1, key_indicator='mAP@0.5IOU')
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/configs/detection/ava/slowonly_omnisource_pretrained_r50_4x16x1_20e_ava_rgb.py
+++ b/configs/detection/ava/slowonly_omnisource_pretrained_r50_4x16x1_20e_ava_rgb.py
@@ -143,7 +143,12 @@ lr_config = dict(
 total_epochs = 20
 checkpoint_config = dict(interval=1)
 workflow = [('train', 1)]
-evaluation = dict(interval=1)
+# Three avaiable key indicators for ava dataset
+# 'Recall@0.5@100' 'AR@100' 'PascalBoxes_Precision/mAP@0.5IOU'
+evaluation = dict(
+    interval=1,
+    key_indicator='PascalBoxes_Precision/mAP@0.5IOU',
+    rule='greater')
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/configs/detection/ava/slowonly_omnisource_pretrained_r50_4x16x1_20e_ava_rgb.py
+++ b/configs/detection/ava/slowonly_omnisource_pretrained_r50_4x16x1_20e_ava_rgb.py
@@ -143,12 +143,7 @@ lr_config = dict(
 total_epochs = 20
 checkpoint_config = dict(interval=1)
 workflow = [('train', 1)]
-# Three avaiable key indicators for ava dataset
-# 'Recall@0.5@100' 'AR@100' 'PascalBoxes_Precision/mAP@0.5IOU'
-evaluation = dict(
-    interval=1,
-    key_indicator='PascalBoxes_Precision/mAP@0.5IOU',
-    rule='greater')
+evaluation = dict(interval=1, key_indicator='mAP@0.5IOU')
 log_config = dict(
     interval=20, hooks=[
         dict(type='TextLoggerHook'),

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,18 @@
 
 ### master
 
+**Highlights**
+
+**New Features**
+
+**Improvements**
+
+**Bug and Typo Fixes**
+
++ Fix a bug about ava dataset validation ([#527](https://github.com/open-mmlab/mmaction2/pull/527).
+
+**ModelZoo**
+
 ### 0.10.0 (31/12/2020)
 
 **Highlights**

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@
 
 **Bug and Typo Fixes**
 
-+ Fix a bug about ava dataset validation ([#527](https://github.com/open-mmlab/mmaction2/pull/527).
+- Fix a bug about ava dataset validation ([#527](https://github.com/open-mmlab/mmaction2/pull/527).
 
 **ModelZoo**
 

--- a/mmaction/core/evaluation/ava_evaluation/object_detection_evaluation.py
+++ b/mmaction/core/evaluation/ava_evaluation/object_detection_evaluation.py
@@ -304,7 +304,7 @@ class ObjectDetectionEvaluator(DetectionEvaluator):
             mean_corloc,
         ) = self._evaluation.evaluate()
 
-        metric = 'mAP@{}IOU'.format(self._matching_iou_threshold)
+        metric = f'mAP@{self._matching_iou_threshold}IOU'
         pascal_metrics = {self._metric_prefix + metric: mean_ap}
         if self._evaluate_corlocs:
             pascal_metrics[self._metric_prefix +

--- a/mmaction/core/evaluation/ava_evaluation/object_detection_evaluation.py
+++ b/mmaction/core/evaluation/ava_evaluation/object_detection_evaluation.py
@@ -304,7 +304,7 @@ class ObjectDetectionEvaluator(DetectionEvaluator):
             mean_corloc,
         ) = self._evaluation.evaluate()
 
-        metric = 'Precision/mAP@{}IOU'.format(self._matching_iou_threshold)
+        metric = 'mAP@{}IOU'.format(self._matching_iou_threshold)
         pascal_metrics = {self._metric_prefix + metric: mean_ap}
         if self._evaluate_corlocs:
             pascal_metrics[self._metric_prefix +
@@ -353,7 +353,6 @@ class PascalDetectionEvaluator(ObjectDetectionEvaluator):
             categories,
             matching_iou_threshold=matching_iou_threshold,
             evaluate_corlocs=False,
-            metric_prefix='PascalBoxes',
             use_weighted_mean_ap=False,
         )
 

--- a/mmaction/core/evaluation/eval_hooks.py
+++ b/mmaction/core/evaluation/eval_hooks.py
@@ -35,7 +35,9 @@ class EpochEvalHook(Hook):
             ``mean_average_precision``, ``mmit_mean_average_precision``
             for action recognition dataset (RawframeDataset and VideoDataset).
             ``AR@AN``, ``auc`` for action localization dataset
-            (ActivityNetDataset). Default: `top1_acc`.
+            (ActivityNetDataset). ``Recall@0.5@100``, ``AR@100``,
+            ``mAP@0.5IOU`` for spatio-temporal action detection dataset
+            (AVADataset). Default: `top1_acc`.
         rule (str | None): Comparison rule for best score. Options are None,
             'greater' and 'less'. If set to None, it will infer a reasonable
             rule. Default: 'None'.
@@ -45,7 +47,7 @@ class EpochEvalHook(Hook):
 
     rule_map = {'greater': lambda x, y: x > y, 'less': lambda x, y: x < y}
     init_value_map = {'greater': -inf, 'less': inf}
-    greater_keys = ['acc', 'top', 'AR@', 'auc', 'precision']
+    greater_keys = ['acc', 'top', 'AR@', 'auc', 'precision', 'mAP@', 'Recall@']
     less_keys = ['loss']
 
     def __init__(self,

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -83,8 +83,7 @@ def test_ava_detection():
 
     # eval bbox
     detection = ava_eval(result_path, 'bbox', label_map, gt_path, None)
-    assert_array_almost_equal(detection['PascalBoxes_Precision/mAP@0.5IOU'],
-                              0.09385522)
+    assert_array_almost_equal(detection['mAP@0.5IOU'], 0.09385522)
 
 
 def test_confusion_matrix():

--- a/tests/test_data/test_ava_dataset.py
+++ b/tests/test_data/test_ava_dataset.py
@@ -172,5 +172,4 @@ class TestAVADataset:
         res = ava_dataset.evaluate(fake_result)
         assert_array_almost_equal(res['Recall@0.5@100'], 0.33333333)
         assert_array_almost_equal(res['AR@100'], 0.15833333)
-        assert_array_almost_equal(res['PascalBoxes_Precision/mAP@0.5IOU'],
-                                  0.027777778)
+        assert_array_almost_equal(res['mAP@0.5IOU'], 0.027777778)


### PR DESCRIPTION
+ Description: When training ava dataset with default configs, no validaton results stored.
+ Multi-GPU
  + script: `tools/dist_train.sh configs/detection/ava/slowonly_kinetics_pretrained_r50_4x16x1_20e_ava_rgb.py 8 --validate`
  + details: successfully run eval after every epoch, but `best.json` is not created in work dir.
+ single-gpu:
  + script: `python tools/train.py configs/detection/ava/slowonly_kinetics_pretrained_r50_4x16x1_20e_ava_rgb.py --validate`
  + details: sucessfully run ava eval, but `TypeError` occured.

```
/ssd01/zhangyiyang/mmaction2_github/mmaction/core/evaluation/eval_hooks.py:176: UserWarning: The key indicator for evaluation is not included in evaluation result, please specify it in config file
  warnings.warn('The key indicator for evaluation is not '
Traceback (most recent call last):
  File "tools/train.py", line 178, in <module>
    main()
  File "tools/train.py", line 174, in main
    meta=meta)
  File "/ssd01/zhangyiyang/mmaction2_github/mmaction/apis/train.py", line 156, in train_model
    runner.run(data_loaders, cfg.workflow, cfg.total_epochs, **runner_kwargs)
  File "/home/ubuntu/anaconda3/envs/zyy_pytorch1.6/lib/python3.7/site-packages/mmcv/runner/epoch_based_runner.py", line 125, in run
    epoch_runner(data_loaders[i], **kwargs)
  File "/home/ubuntu/anaconda3/envs/zyy_pytorch1.6/lib/python3.7/site-packages/mmcv/runner/epoch_based_runner.py", line 54, in train
    self.call_hook('after_train_epoch')
  File "/home/ubuntu/anaconda3/envs/zyy_pytorch1.6/lib/python3.7/site-packages/mmcv/runner/base_runner.py", line 307, in call_hook
    getattr(hook, fn_name)(self)
  File "/ssd01/zhangyiyang/mmaction2_github/mmaction/core/evaluation/eval_hooks.py", line 153, in after_train_epoch
    if (self.save_best and self.compare_func(key_score, self.best_score)):
  File "/ssd01/zhangyiyang/mmaction2_github/mmaction/core/evaluation/eval_hooks.py", line 46, in <lambda>
    rule_map = {'greater': lambda x, y: x > y, 'less': lambda x, y: x < y}
TypeError: '>' not supported between instances of 'NoneType' and 'float'
```

+ Locating BUG: `key_indicator` for eval hook is not set. Default `key_indicator` is `top1_acc`, which is useless for ava dataset.

+ Modification:
    + set default `key_indicator='mAP@0.5IOU'` for ava dataset configs.
    + rename ava metrics `PascalBoxes_Precision/mAP@0.5IOU` to `mAP@0.5IOU`
    + modify eval hook, add docs & keys for `greater_keys`