### PR TITLE
[Fix] Fix a bug about inference config.

### DIFF
--- a/configs/recognition/i3d/i3d_r50_video_inference_32x2x1_100e_kinetics400_rgb.py
+++ b/configs/recognition/i3d/i3d_r50_video_inference_32x2x1_100e_kinetics400_rgb.py
@@ -28,3 +28,6 @@ data = dict(
         ann_file=None,
         data_prefix=None,
         pipeline=test_pipeline))
+
+# runtime settings
+dist_params = dict(backend='nccl')

--- a/configs/recognition/r2plus1d/r2plus1d_r34_video_inference_8x8x1_180e_kinetics400_rgb.py
+++ b/configs/recognition/r2plus1d/r2plus1d_r34_video_inference_8x8x1_180e_kinetics400_rgb.py
@@ -33,3 +33,6 @@ data = dict(
         ann_file=None,
         data_prefix=None,
         pipeline=test_pipeline))
+
+# runtime settings
+dist_params = dict(backend='nccl')

--- a/configs/recognition/slowfast/slowfast_r50_video_inference_4x16x1_256e_kinetics400_rgb.py
+++ b/configs/recognition/slowfast/slowfast_r50_video_inference_4x16x1_256e_kinetics400_rgb.py
@@ -30,3 +30,6 @@ data = dict(
         ann_file=None,
         data_prefix=None,
         pipeline=test_pipeline))
+
+# runtime settings
+dist_params = dict(backend='nccl')

--- a/configs/recognition/slowonly/slowonly_r50_video_inference_4x16x1_256e_kinetics400_rgb.py
+++ b/configs/recognition/slowonly/slowonly_r50_video_inference_4x16x1_256e_kinetics400_rgb.py
@@ -31,3 +31,6 @@ data = dict(
         ann_file=None,
         data_prefix=None,
         pipeline=test_pipeline))
+
+# runtime settings
+dist_params = dict(backend='nccl')

--- a/configs/recognition/tsm/tsm_r50_video_inference_1x1x8_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsm/tsm_r50_video_inference_1x1x8_100e_kinetics400_rgb.py
@@ -29,3 +29,6 @@ data = dict(
         ann_file=None,
         data_prefix=None,
         pipeline=test_pipeline))
+
+# runtime settings
+dist_params = dict(backend='nccl')

--- a/configs/recognition/tsn/tsn_r50_inference_1x1x3_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsn/tsn_r50_inference_1x1x3_100e_kinetics400_rgb.py
@@ -28,3 +28,6 @@ data = dict(
         ann_file=None,
         data_prefix=None,
         pipeline=test_pipeline))
+
+# runtime settings
+dist_params = dict(backend='nccl')

--- a/configs/recognition/tsn/tsn_r50_video_inference_1x1x3_100e_kinetics400_rgb.py
+++ b/configs/recognition/tsn/tsn_r50_video_inference_1x1x3_100e_kinetics400_rgb.py
@@ -29,3 +29,6 @@ data = dict(
         ann_file=None,
         data_prefix=None,
         pipeline=test_pipeline))
+
+# runtime settings
+dist_params = dict(backend='nccl')


### PR DESCRIPTION
When running `./tools/dist_test.sh` with inference config, an `AttributeError` occurs.

```shell
Traceback (most recent call last):
  File "./tools/test.py", line 203, in <module>
    main()
  File "./tools/test.py", line 156, in main
    init_dist(args.launcher, **cfg.dist_params)
  File "/home/ubuntu/anaconda3/envs/zyy_pytorch1.6/lib/python3.7/site-packages/mmcv/utils/config.py", line 398, in __getattr__
    return getattr(self._cfg_dict, name)
  File "/home/ubuntu/anaconda3/envs/zyy_pytorch1.6/lib/python3.7/site-packages/mmcv/utils/config.py", line 43, in __getattr__
    raise ex
AttributeError: 'ConfigDict' object has no attribute 'dist_params'
```

Apparently, `dist_params` is required for `test.py`