### PR TITLE
[Improvement] Support soft label for CrossEntropyLoss

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,7 +18,7 @@
 **Improvements**
 
 - Training custom classes of ava dataset ([#555](https://github.com/open-mmlab/mmaction2/pull/555))
-- Support non-sparse(one-hot like) label for CrossEntropyLoss ([#625](https://github.com/open-mmlab/mmaction2/pull/625))
+- Support soft label for CrossEntropyLoss ([#625](https://github.com/open-mmlab/mmaction2/pull/625))
 
 **Bug and Typo Fixes**
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,23 +15,16 @@
 - Support GPU Normalize ([#586](https://github.com/open-mmlab/mmaction2/pull/586))
 - Support TANet ([#595](https://github.com/open-mmlab/mmaction2/pull/595))
 
-**ModelZoo**
-
-- Add TSM-MobileNetV2 for Kinetics400 ([#415](https://github.com/open-mmlab/mmaction2/pull/415))
-
-### 0.11.0 (31/01/2021)
-
-**Highlights**
-
-**New Features**
-
 **Improvements**
 
 - Training custom classes of ava dataset ([#555](https://github.com/open-mmlab/mmaction2/pull/555))
+- Support non-sparse(one-hot like) label for CrossEntropyLoss ([#625](https://github.com/open-mmlab/mmaction2/pull/625))
 
 **Bug and Typo Fixes**
 
 **ModelZoo**
+
+- Add TSM-MobileNetV2 for Kinetics400 ([#415](https://github.com/open-mmlab/mmaction2/pull/415))
 
 ### 0.11.0 (31/01/2021)
 

--- a/mmaction/models/losses/cross_entropy_loss.py
+++ b/mmaction/models/losses/cross_entropy_loss.py
@@ -44,18 +44,15 @@ class CrossEntropyLoss(BaseWeightedLoss):
             torch.Tensor: The returned CrossEntropy loss.
         """
         if self.sparse_label:
-            # sparse labels
             if self.class_weight is not None:
                 assert 'weight' not in kwargs, \
                     "The key 'weight' already exists."
                 kwargs['weight'] = self.class_weight.to(cls_score.device)
             loss_cls = F.cross_entropy(cls_score, label, **kwargs)
         else:
-            # non-sparse(one-hot like) labels
             assert cls_score.size() == label.size()
             assert cls_score.dim() == 2
 
-            # cal cross entropy loss with one-hot like labels
             lsm = F.log_softmax(cls_score, 1)
             if self.class_weight is not None:
                 lsm = lsm * self.class_weight.unsqueeze(0)

--- a/mmaction/models/losses/cross_entropy_loss.py
+++ b/mmaction/models/losses/cross_entropy_loss.py
@@ -9,6 +9,16 @@ from .base import BaseWeightedLoss
 class CrossEntropyLoss(BaseWeightedLoss):
     """Cross Entropy Loss.
 
+    Support two kinds of labels and their corresponding loss type. It's worth
+    mentioning that loss type will be detected by the shape of ``cls_score``
+    and ``label``.
+    1) Sparse label: integers in range [0, num_classes - 1].
+    2) Non-sparse label(one-hot like labels): floats in range [0, 1]. It shares
+        the same shape with ``cls_score``.
+
+    For example, if the number of classes is 4, sparse labels could be [0, 2]
+    and its corresponding non-sparse labels are [[1, 0, 0, 0], [0, 0, 1, 0]].
+
     Args:
         loss_weight (float): Factor scalar multiplied on the loss.
             Default: 1.0.
@@ -29,13 +39,7 @@ class CrossEntropyLoss(BaseWeightedLoss):
 
         Args:
             cls_score (torch.Tensor): The class score.
-            label (torch.Tensor): The ground truth label. Support two kinds of
-                label, sparse label and non-sparse label. Sparse labels are
-                integers in range [0, num_classes - 1]. Non-sparse labels, or
-                one-hot like labels, are floats in range [0, 1]. If the shape
-                of ``cls_score`` is [N, num_classes], the shape of ``label``
-                should be [N] for sparse labels and [N, num_classes] for
-                non-sparse labels.
+            label (torch.Tensor): The ground truth label.
             kwargs: Any keyword argument to be used to calculate
                 CrossEntropy loss.
 
@@ -43,6 +47,8 @@ class CrossEntropyLoss(BaseWeightedLoss):
             torch.Tensor: The returned CrossEntropy loss.
         """
         if cls_score.size() == label.size():
+            # cal loss for non-sparse(one-hot like) label
+
             assert cls_score.dim() == 2, 'Only support 2-dim non-sparse labels'
 
             lsm = F.log_softmax(cls_score, 1)
@@ -59,6 +65,8 @@ class CrossEntropyLoss(BaseWeightedLoss):
             else:
                 loss_cls = loss_cls.mean()
         else:
+            # cal loss for sparse label
+
             if self.class_weight is not None:
                 assert 'weight' not in kwargs, \
                     "The key 'weight' already exists."

--- a/mmaction/models/losses/cross_entropy_loss.py
+++ b/mmaction/models/losses/cross_entropy_loss.py
@@ -15,10 +15,10 @@ class CrossEntropyLoss(BaseWeightedLoss):
     1) Hard label: This label is an integer array and all of the elements are
         in the range [0, num_classes - 1]. This label's shape should be
         ``cls_score``'s shape with the `num_classes` dimension removed.
-    2) Soft label(one-hot like label): This label is a probability distribution
-        and all of the elements are in the range [0, 1]. This label's shape
-        must be the same as ``cls_score``. For now, only 2-dim soft label is
-        supported.
+    2) Soft label(probablity distribution over classes): This label is a
+        probability distribution and all of the elements are in the range
+        [0, 1]. This label's shape must be the same as ``cls_score``. For now,
+        only 2-dim soft label is supported.
 
     Args:
         loss_weight (float): Factor scalar multiplied on the loss.

--- a/mmaction/models/losses/cross_entropy_loss.py
+++ b/mmaction/models/losses/cross_entropy_loss.py
@@ -16,13 +16,20 @@ class CrossEntropyLoss(BaseWeightedLoss):
             as None, use the same weight 1 for all classes. Only applies
             to CrossEntropyLoss and BCELossWithLogits (should not be set when
             using other losses). Default: None.
+        sparse_label (bool): Whether to use sparse labels or not. Sparse labels
+            are integers in range [0, num_classes - 1]. Non sparse labels, or
+            one-hot like labels, are floats in range [0, 1]. If the shape of
+            ``cls_score`` is [N, num_classes], the shape of ``label`` should be
+            [N] for sparse labels and [N, num_classes] for non-sparse labels.
+            Default: True.
     """
 
-    def __init__(self, loss_weight=1.0, class_weight=None):
+    def __init__(self, loss_weight=1.0, class_weight=None, sparse_label=True):
         super().__init__(loss_weight=loss_weight)
         self.class_weight = None
         if class_weight is not None:
             self.class_weight = torch.Tensor(class_weight)
+        self.sparse_label = sparse_label
 
     def _forward(self, cls_score, label, **kwargs):
         """Forward function.
@@ -36,10 +43,33 @@ class CrossEntropyLoss(BaseWeightedLoss):
         Returns:
             torch.Tensor: The returned CrossEntropy loss.
         """
-        if self.class_weight is not None:
-            assert 'weight' not in kwargs, "The key 'weight' already exists."
-            kwargs['weight'] = self.class_weight.to(cls_score.device)
-        loss_cls = F.cross_entropy(cls_score, label, **kwargs)
+        if self.sparse_label:
+            # sparse labels
+            if self.class_weight is not None:
+                assert 'weight' not in kwargs, \
+                    "The key 'weight' already exists."
+                kwargs['weight'] = self.class_weight.to(cls_score.device)
+            loss_cls = F.cross_entropy(cls_score, label, **kwargs)
+        else:
+            # non-sparse(one-hot like) labels
+            assert cls_score.size() == label.size()
+            assert cls_score.dim() == 2
+
+            # cal cross entropy loss with one-hot like labels
+            lsm = F.log_softmax(cls_score, 1)
+            if self.class_weight is not None:
+                lsm = lsm * self.class_weight.unsqueeze(0)
+            loss_cls = -(label * lsm).sum(1)
+
+            # default reduction 'mean'
+            if self.class_weight is not None:
+                # Use weighted average as pytorch CrossEntropyLoss does.
+                # For more information, please visit https://pytorch.org/docs/stable/generated/torch.nn.CrossEntropyLoss.html # noqa
+                loss_cls = loss_cls.sum() / torch.sum(
+                    self.class_weight.unsqueeze(0) * label)
+            else:
+                loss_cls = loss_cls.mean()
+
         return loss_cls
 
 

--- a/mmaction/models/losses/cross_entropy_loss.py
+++ b/mmaction/models/losses/cross_entropy_loss.py
@@ -48,7 +48,7 @@ class CrossEntropyLoss(BaseWeightedLoss):
             torch.Tensor: The returned CrossEntropy loss.
         """
         if cls_score.size() == label.size():
-            # cal loss for soft label
+            # calculate loss for soft label
 
             assert cls_score.dim() == 2, 'Only support 2-dim soft label'
             assert len(kwargs) == 0, \
@@ -69,7 +69,7 @@ class CrossEntropyLoss(BaseWeightedLoss):
             else:
                 loss_cls = loss_cls.mean()
         else:
-            # cal loss for hard label
+            # calculate loss for hard label
 
             if self.class_weight is not None:
                 assert 'weight' not in kwargs, \

--- a/mmaction/models/losses/cross_entropy_loss.py
+++ b/mmaction/models/losses/cross_entropy_loss.py
@@ -12,12 +12,16 @@ class CrossEntropyLoss(BaseWeightedLoss):
     Support two kinds of labels and their corresponding loss type. It's worth
     mentioning that loss type will be detected by the shape of ``cls_score``
     and ``label``.
-    1) Sparse label: integers in range [0, num_classes - 1].
-    2) Non-sparse label(one-hot like labels): floats in range [0, 1]. It shares
-        the same shape with ``cls_score``.
+    1) Sparse label: This label is an integer array and all of the elements are
+        in the range [0, num_classes - 1]. This label's shape should be
+        ``cls_score``'s shape with the `num_classes` dimension removed.
+    2) Soft label(one-hot like label): This label is a probability distribution
+        and all of the elements are in the range [0, 1]. This label's shape
+        must be the same as ``cls_score``. For now, only 2-dim soft label is
+        supported.
 
-    For example, if the number of classes is 4, sparse labels could be [0, 2]
-    and its corresponding non-sparse labels are [[1, 0, 0, 0], [0, 0, 1, 0]].
+    For example, if the number of classes is 4, sparse label could be [0, 2]
+    and its corresponding soft label is [[1, 0, 0, 0], [0, 0, 1, 0]].
 
     Args:
         loss_weight (float): Factor scalar multiplied on the loss.
@@ -47,9 +51,9 @@ class CrossEntropyLoss(BaseWeightedLoss):
             torch.Tensor: The returned CrossEntropy loss.
         """
         if cls_score.size() == label.size():
-            # cal loss for non-sparse(one-hot like) label
+            # cal loss for soft label
 
-            assert cls_score.dim() == 2, 'Only support 2-dim non-sparse labels'
+            assert cls_score.dim() == 2, 'Only support 2-dim soft label'
 
             lsm = F.log_softmax(cls_score, 1)
             if self.class_weight is not None:

--- a/mmaction/models/losses/cross_entropy_loss.py
+++ b/mmaction/models/losses/cross_entropy_loss.py
@@ -12,16 +12,13 @@ class CrossEntropyLoss(BaseWeightedLoss):
     Support two kinds of labels and their corresponding loss type. It's worth
     mentioning that loss type will be detected by the shape of ``cls_score``
     and ``label``.
-    1) Sparse label: This label is an integer array and all of the elements are
+    1) Hard label: This label is an integer array and all of the elements are
         in the range [0, num_classes - 1]. This label's shape should be
         ``cls_score``'s shape with the `num_classes` dimension removed.
     2) Soft label(one-hot like label): This label is a probability distribution
         and all of the elements are in the range [0, 1]. This label's shape
         must be the same as ``cls_score``. For now, only 2-dim soft label is
         supported.
-
-    For example, if the number of classes is 4, sparse label could be [0, 2]
-    and its corresponding soft label is [[1, 0, 0, 0], [0, 0, 1, 0]].
 
     Args:
         loss_weight (float): Factor scalar multiplied on the loss.
@@ -54,6 +51,9 @@ class CrossEntropyLoss(BaseWeightedLoss):
             # cal loss for soft label
 
             assert cls_score.dim() == 2, 'Only support 2-dim soft label'
+            assert len(kwargs) == 0, \
+                ('For now, no extra args are supported for soft label, '
+                 f'but get {kwargs}')
 
             lsm = F.log_softmax(cls_score, 1)
             if self.class_weight is not None:
@@ -69,7 +69,7 @@ class CrossEntropyLoss(BaseWeightedLoss):
             else:
                 loss_cls = loss_cls.mean()
         else:
-            # cal loss for sparse label
+            # cal loss for hard label
 
             if self.class_weight is not None:
                 assert 'weight' not in kwargs, \

--- a/tests/test_metrics/test_losses.py
+++ b/tests/test_metrics/test_losses.py
@@ -101,14 +101,13 @@ def test_cross_entropy_loss():
         F.cross_entropy(cls_scores, sparse_gt_labels, weight=weight))
 
     # non-sparse label without class weight
-    cross_entropy_loss = CrossEntropyLoss(sparse_label=False)
+    cross_entropy_loss = CrossEntropyLoss()
     output_loss = cross_entropy_loss(cls_scores, non_sparse_gt_labels)
     assert torch.equal(output_loss,
                        F.cross_entropy(cls_scores, sparse_gt_labels))
 
     # non-sparse label with class weight
-    cross_entropy_loss = CrossEntropyLoss(
-        sparse_label=False, class_weight=class_weight)
+    cross_entropy_loss = CrossEntropyLoss(class_weight=class_weight)
     output_loss = cross_entropy_loss(cls_scores, non_sparse_gt_labels)
     assert torch.equal(
         output_loss,

--- a/tests/test_metrics/test_losses.py
+++ b/tests/test_metrics/test_losses.py
@@ -4,7 +4,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv import ConfigDict
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_almost_equal
 from torch.autograd import Variable
 
 from mmaction.models import (BCELossWithLogits, BinaryLogisticRegressionLoss,
@@ -103,15 +103,19 @@ def test_cross_entropy_loss():
     # non-sparse label without class weight
     cross_entropy_loss = CrossEntropyLoss()
     output_loss = cross_entropy_loss(cls_scores, non_sparse_gt_labels)
-    assert torch.equal(output_loss,
-                       F.cross_entropy(cls_scores, sparse_gt_labels))
+
+    assert_almost_equal(
+        output_loss.numpy(),
+        F.cross_entropy(cls_scores, sparse_gt_labels).numpy(),
+        decimal=4)
 
     # non-sparse label with class weight
     cross_entropy_loss = CrossEntropyLoss(class_weight=class_weight)
     output_loss = cross_entropy_loss(cls_scores, non_sparse_gt_labels)
-    assert torch.equal(
-        output_loss,
-        F.cross_entropy(cls_scores, sparse_gt_labels, weight=weight))
+    assert_almost_equal(
+        output_loss.numpy(),
+        F.cross_entropy(cls_scores, sparse_gt_labels).numpy(),
+        decimal=4)
 
 
 def test_bce_loss_with_logits():

--- a/tests/test_metrics/test_losses.py
+++ b/tests/test_metrics/test_losses.py
@@ -4,7 +4,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv import ConfigDict
-from numpy.testing import assert_array_almost_equal, assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_array_almost_equal
 from torch.autograd import Variable
 
 from mmaction.models import (BCELossWithLogits, BinaryLogisticRegressionLoss,
@@ -83,7 +83,7 @@ def test_cross_entropy_loss():
     cls_scores = torch.rand((3, 4))
     sparse_gt_labels = torch.LongTensor([0, 1, 2]).squeeze()
     soft_gt_labels = torch.FloatTensor([[1, 0, 0, 0], [0, 1, 0, 0],
-                                              [0, 0, 1, 0]]).squeeze()
+                                        [0, 0, 1, 0]]).squeeze()
 
     # sparse label without weight
     cross_entropy_loss = CrossEntropyLoss()

--- a/tests/test_metrics/test_losses.py
+++ b/tests/test_metrics/test_losses.py
@@ -81,31 +81,31 @@ def test_hvu_loss():
 
 def test_cross_entropy_loss():
     cls_scores = torch.rand((3, 4))
-    sparse_gt_labels = torch.LongTensor([0, 1, 2]).squeeze()
+    hard_gt_labels = torch.LongTensor([0, 1, 2]).squeeze()
     soft_gt_labels = torch.FloatTensor([[1, 0, 0, 0], [0, 1, 0, 0],
                                         [0, 0, 1, 0]]).squeeze()
 
-    # sparse label without weight
+    # hard label without weight
     cross_entropy_loss = CrossEntropyLoss()
-    output_loss = cross_entropy_loss(cls_scores, sparse_gt_labels)
-    assert torch.equal(output_loss,
-                       F.cross_entropy(cls_scores, sparse_gt_labels))
+    output_loss = cross_entropy_loss(cls_scores, hard_gt_labels)
+    assert torch.equal(output_loss, F.cross_entropy(cls_scores,
+                                                    hard_gt_labels))
 
-    # sparse label with class weight
+    # hard label with class weight
     weight = torch.rand(4)
     class_weight = weight.numpy().tolist()
     cross_entropy_loss = CrossEntropyLoss(class_weight=class_weight)
-    output_loss = cross_entropy_loss(cls_scores, sparse_gt_labels)
+    output_loss = cross_entropy_loss(cls_scores, hard_gt_labels)
     assert torch.equal(
         output_loss,
-        F.cross_entropy(cls_scores, sparse_gt_labels, weight=weight))
+        F.cross_entropy(cls_scores, hard_gt_labels, weight=weight))
 
     # soft label without class weight
     cross_entropy_loss = CrossEntropyLoss()
     output_loss = cross_entropy_loss(cls_scores, soft_gt_labels)
     assert_almost_equal(
         output_loss.numpy(),
-        F.cross_entropy(cls_scores, sparse_gt_labels).numpy(),
+        F.cross_entropy(cls_scores, hard_gt_labels).numpy(),
         decimal=4)
 
     # soft label with class weight
@@ -113,7 +113,7 @@ def test_cross_entropy_loss():
     output_loss = cross_entropy_loss(cls_scores, soft_gt_labels)
     assert_almost_equal(
         output_loss.numpy(),
-        F.cross_entropy(cls_scores, sparse_gt_labels, weight=weight).numpy(),
+        F.cross_entropy(cls_scores, hard_gt_labels, weight=weight).numpy(),
         decimal=4)
 
 

--- a/tests/test_metrics/test_losses.py
+++ b/tests/test_metrics/test_losses.py
@@ -82,7 +82,7 @@ def test_hvu_loss():
 def test_cross_entropy_loss():
     cls_scores = torch.rand((3, 4))
     sparse_gt_labels = torch.LongTensor([0, 1, 2]).squeeze()
-    non_sparse_gt_labels = torch.FloatTensor([[1, 0, 0, 0], [0, 1, 0, 0],
+    soft_gt_labels = torch.FloatTensor([[1, 0, 0, 0], [0, 1, 0, 0],
                                               [0, 0, 1, 0]]).squeeze()
 
     # sparse label without weight
@@ -100,18 +100,18 @@ def test_cross_entropy_loss():
         output_loss,
         F.cross_entropy(cls_scores, sparse_gt_labels, weight=weight))
 
-    # non-sparse label without class weight
+    # soft label without class weight
     cross_entropy_loss = CrossEntropyLoss()
-    output_loss = cross_entropy_loss(cls_scores, non_sparse_gt_labels)
+    output_loss = cross_entropy_loss(cls_scores, soft_gt_labels)
 
     assert_almost_equal(
         output_loss.numpy(),
         F.cross_entropy(cls_scores, sparse_gt_labels).numpy(),
         decimal=4)
 
-    # non-sparse label with class weight
+    # soft label with class weight
     cross_entropy_loss = CrossEntropyLoss(class_weight=class_weight)
-    output_loss = cross_entropy_loss(cls_scores, non_sparse_gt_labels)
+    output_loss = cross_entropy_loss(cls_scores, soft_gt_labels)
     assert_almost_equal(
         output_loss.numpy(),
         F.cross_entropy(cls_scores, sparse_gt_labels).numpy(),

--- a/tests/test_metrics/test_losses.py
+++ b/tests/test_metrics/test_losses.py
@@ -103,7 +103,6 @@ def test_cross_entropy_loss():
     # soft label without class weight
     cross_entropy_loss = CrossEntropyLoss()
     output_loss = cross_entropy_loss(cls_scores, soft_gt_labels)
-
     assert_almost_equal(
         output_loss.numpy(),
         F.cross_entropy(cls_scores, sparse_gt_labels).numpy(),
@@ -114,7 +113,7 @@ def test_cross_entropy_loss():
     output_loss = cross_entropy_loss(cls_scores, soft_gt_labels)
     assert_almost_equal(
         output_loss.numpy(),
-        F.cross_entropy(cls_scores, sparse_gt_labels).numpy(),
+        F.cross_entropy(cls_scores, sparse_gt_labels, weight=weight).numpy(),
         decimal=4)
 
 


### PR DESCRIPTION
## Motivation
Soft labels are required for data augmentation methods like mixup, cutmix, etc. For now, official `CrossEntropyLoss`  doesn't support soft labels.

## Details
+ If number of classes is 4.
    + Hard labels example: `[0, 1, 2]`
    + Corresponding soft labels are `[[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0]]`
    + Mixup/Cutmix may create soft labels like `[[0.8, 0.2, 0, 0], [0.1, 0.9, 0, 0], [0, 0, 0.6, 0.4]]`
+ It's difficult to get a proper name for this pr and related args.
    + `Sparse` is borrowed from TensorFlow and MXNet, TensorFlow has  `CategoricalCrossentropy`(accept non-sparse, one-hot like labels) and `SparseCategorialCrossentropy`(just like `CrossEntropyLoss` in pytorch).
    + BTW, **one-hot like labels** is more clear and meaningful for me.
+ For now, this pr detects loss type by the shape of label.

## TODO
+ [x] Modify `CrossEntropyLoss` in `mmaction/models/losses/cross_entropy_loss.py`.
+ [x] unittest
+ [x]  changelog.