### PR TITLE
Bump version to v0.12.0

### DIFF
--- a/mmaction/__init__.py
+++ b/mmaction/__init__.py
@@ -3,7 +3,7 @@ from mmcv import digit_version
 
 from .version import __version__
 
-mmcv_minimum_version = '1.1.1'
+mmcv_minimum_version = '1.2.6'
 mmcv_maximum_version = '1.3'
 mmcv_version = digit_version(mmcv.__version__)
 

--- a/mmaction/version.py
+++ b/mmaction/version.py
@@ -1,6 +1,6 @@
 # Copyright (c) Open-MMLab. All rights reserved.
 
-__version__ = '0.11.0'
+__version__ = '0.12.0'
 
 
 def parse_version_info(version_str):


### PR DESCRIPTION
1. Bump new version
2. upper `mmcv_minimum_version` due to https://github.com/open-mmlab/mmcv/pull/743