### PR TITLE
Remove train test cfg in bmn and bsn

### DIFF
--- a/configs/_base_/models/bmn_400x100.py
+++ b/configs/_base_/models/bmn_400x100.py
@@ -10,6 +10,3 @@ model = dict(
     soft_nms_low_threshold=0.5,
     soft_nms_high_threshold=0.9,
     post_process_top_k=100)
-# model training and testing settings
-train_cfg = None
-test_cfg = dict(average_clips='score')

--- a/configs/_base_/models/bsn_pem.py
+++ b/configs/_base_/models/bsn_pem.py
@@ -11,6 +11,3 @@ model = dict(
     soft_nms_low_threshold=0.65,
     soft_nms_high_threshold=0.9,
     post_process_top_k=100)
-# model training and testing settings
-train_cfg = None
-test_cfg = dict(average_clips='score')

--- a/configs/_base_/models/bsn_tem.py
+++ b/configs/_base_/models/bsn_tem.py
@@ -6,6 +6,3 @@ model = dict(
     tem_feat_dim=400,
     tem_hidden_dim=512,
     tem_match_threshold=0.5)
-# model training and testing settings
-train_cfg = None
-test_cfg = dict(average_clips='score')

--- a/tools/test.py
+++ b/tools/test.py
@@ -124,17 +124,22 @@ def main():
 
     dataset_type = cfg.data.test.type
     if output_config.get('out', None):
-        out = output_config['out']
-        # make sure the dirname of the output path exists
-        mmcv.mkdir_or_exist(osp.dirname(out))
-        _, suffix = osp.splitext(out)
-        if dataset_type == 'AVADataset':
-            assert suffix[1:] == 'csv', ('For AVADataset, the format of the '
-                                         'output file should be csv')
+        if 'output_format' in output_config:
+            # ugly workround to make recognition and localization the same
+            warnings.warn(
+                'Skip checking `output_format` in localization task.')
         else:
-            assert suffix[1:] in file_handlers, (
-                'The format of the output '
-                'file should be json, pickle or yaml')
+            out = output_config['out']
+            # make sure the dirname of the output path exists
+            mmcv.mkdir_or_exist(osp.dirname(out))
+            _, suffix = osp.splitext(out)
+            if dataset_type == 'AVADataset':
+                assert suffix[1:] == 'csv', ('For AVADataset, the format of '
+                                             'the output file should be csv')
+            else:
+                assert suffix[1:] in file_handlers, (
+                    'The format of the output '
+                    'file should be json, pickle or yaml')
 
     # set cudnn benchmark
     if cfg.get('cudnn_benchmark', False):
@@ -143,7 +148,7 @@ def main():
 
     if args.average_clips is not None:
         # You can set average_clips during testing, it will override the
-        # original settting
+        # original setting
         if cfg.model.get('test_cfg') is None and cfg.get('test_cfg') is None:
             cfg.model.setdefault('test_cfg',
                                  dict(average_clips=args.average_clips))

--- a/tools/test.py
+++ b/tools/test.py
@@ -141,13 +141,13 @@ def main():
         torch.backends.cudnn.benchmark = True
     cfg.data.test.test_mode = True
 
-    if cfg.model.get('test_cfg') is None and cfg.get('test_cfg') is None:
-        cfg.model.setdefault('test_cfg',
-                             dict(average_clips=args.average_clips))
-    else:
+    if args.average_clips is not None:
         # You can set average_clips during testing, it will override the
         # original settting
-        if args.average_clips is not None:
+        if cfg.model.get('test_cfg') is None and cfg.get('test_cfg') is None:
+            cfg.model.setdefault('test_cfg',
+                                 dict(average_clips=args.average_clips))
+        else:
             if cfg.model.get('test_cfg') is not None:
                 cfg.model.test_cfg.average_clips = args.average_clips
             else:


### PR DESCRIPTION
`train_cfg` and `test_cfg` are useless in bmn and bsn.

fix #662 