### PR TITLE
[Improvement] Add softmax option for pytorch2onnx tool.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,19 @@
 ## Changelog
 
+### Master
+
+**Highlights**
+
+**New Features**
+
+**Improvements**
+
+- Add softmax option for pytorch2onnx tool ([#781](https://github.com/open-mmlab/mmaction2/pull/781))
+
+**Bug and Typo Fixes**
+
+**ModelZoo**
+
 ### 0.13.0 (31/03/2021)
 
 **Highlights**

--- a/docs/tutorials/6_export_model.md
+++ b/docs/tutorials/6_export_model.md
@@ -53,6 +53,7 @@ Optional arguments:
 - `--output-file`: The output onnx model name. If not specified, it will be set to `tmp.onnx`.
 - `--is-localizer`: Determines whether the model to be exported is a localizer. If not specified, it will be set to `False`.
 - `--opset-version`: Determines the operation set version of onnx, we recommend you to use a higher version such as 11 for compatibility. If not specified, it will be set to `11`.
+- `--softmax`: Determines whether to add a softmax layer at the end of recognizers. If not specified, it will be set to `False`. For now, localizers are not supported.
 
 ### Recognizers
 

--- a/docs/useful_tools.md
+++ b/docs/useful_tools.md
@@ -98,6 +98,7 @@ You may use the result for simple comparisons, but double check it before you ad
 `/tools/pytorch2onnx.py` is a script to convert model to [ONNX](https://github.com/onnx/onnx) format.
 It also supports comparing the output results between Pytorch and ONNX model for verification.
 Run `pip install onnx onnxruntime` first to install the dependency.
+Please note that a softmax layer could be added for recognizers by `--softmax` option, in order to get predictions in range `[0, 1]`.
 
 - For recognizers, please run:
 

--- a/docs_zh_CN/tutorials/6_export_model.md
+++ b/docs_zh_CN/tutorials/6_export_model.md
@@ -54,6 +54,7 @@ python tools/pytorch2onnx.py ${CONFIG_FILE} ${CHECKPOINT_FILE} [--shape ${SHAPE}
 - `--output-file`: 导出的 onnx 模型名。如果没有被指定，它将被置为 `tmp.onnx`。
 - `--is-localizer`：决定导出的模型是否为时序检测器。如果没有被指定，它将被置为 `False`。
 - `--opset-version`：决定 onnx 的执行版本，MMAction2 推荐用户使用高版本（例如 11 版本）的 onnx 以确保稳定性。如果没有被指定，它将被置为 `11`。
+- `--softmax`: 是否在行为识别器末尾添加 Softmax。如果没有指定，将被置为 `False`。目前仅支持行为识别器，不支持时序动作检测器。
 
 ### 行为识别器
 

--- a/docs_zh_CN/useful_tools.md
+++ b/docs_zh_CN/useful_tools.md
@@ -98,6 +98,7 @@ Params: 28.04 M
 `/tools/pytorch2onnx.py` 脚本用于将模型转换为 [ONNX](https://github.com/onnx/onnx) 格式。
 同时，该脚本支持比较 PyTorch 模型和 ONNX 模型的输出结果，验证输出结果是否相同。
 本功能依赖于 `onnx` 以及 `onnxruntime`，使用前请先通过 `pip install onnx onnxruntime` 安装依赖包。
+请注意，可通过 `--softmax` 选项在行为识别器末尾添加 Softmax 层，从而获取 `[0, 1]` 范围内的预测结果。
 
 - 对于行为识别模型，请运行：
 

--- a/mmaction/models/recognizers/recognizer2d.py
+++ b/mmaction/models/recognizers/recognizer2d.py
@@ -131,7 +131,7 @@ class Recognizer2D(BaseRecognizer):
             return self._do_fcn_test(imgs).cpu().numpy()
         return self._do_test(imgs).cpu().numpy()
 
-    def forward_dummy(self, imgs):
+    def forward_dummy(self, imgs, softmax=False):
         """Used for computing network FLOPs.
 
         See ``tools/analysis/get_flops.py``.
@@ -157,8 +157,10 @@ class Recognizer2D(BaseRecognizer):
             x = x.squeeze(2)
             num_segs = 1
 
-        outs = (self.cls_head(x, num_segs), )
-        return outs
+        outs = self.cls_head(x, num_segs)
+        if softmax:
+            outs = nn.functional.softmax(outs)
+        return (outs, )
 
     def forward_gradcam(self, imgs):
         """Defines the computation performed at every call when using gradcam

--- a/mmaction/models/recognizers/recognizer3d.py
+++ b/mmaction/models/recognizers/recognizer3d.py
@@ -1,4 +1,5 @@
 import torch
+from torch import nn
 
 from ..registry import RECOGNIZERS
 from .base import BaseRecognizer
@@ -61,7 +62,7 @@ class Recognizer3D(BaseRecognizer):
         testing."""
         return self._do_test(imgs).cpu().numpy()
 
-    def forward_dummy(self, imgs):
+    def forward_dummy(self, imgs, softmax=False):
         """Used for computing network FLOPs.
 
         See ``tools/analysis/get_flops.py``.
@@ -78,8 +79,10 @@ class Recognizer3D(BaseRecognizer):
         if hasattr(self, 'neck'):
             x, _ = self.neck(x)
 
-        outs = (self.cls_head(x), )
-        return outs
+        outs = self.cls_head(x)
+        if softmax:
+            outs = nn.functional.softmax(outs)
+        return (outs, )
 
     def forward_gradcam(self, imgs):
         """Defines the computation performed at every call when using gradcam

--- a/tests/test_models/test_recognizers/test_recognizer2d.py
+++ b/tests/test_models/test_recognizers/test_recognizer2d.py
@@ -30,6 +30,12 @@ def test_tsn():
     for one_img in img_list:
         recognizer(one_img, gradcam=True)
 
+    # test forward dummy
+    recognizer.forward_dummy(imgs, softmax=False)
+    res = recognizer.forward_dummy(imgs, softmax=True)[0]
+    assert torch.min(res) >= 0
+    assert torch.max(res) <= 1
+
     mmcls_backbone = dict(
         type='mmcls.ResNeXt',
         depth=101,

--- a/tests/test_models/test_recognizers/test_recognizer3d.py
+++ b/tests/test_models/test_recognizers/test_recognizer3d.py
@@ -37,6 +37,12 @@ def test_i3d():
             for one_img in img_list:
                 recognizer(one_img, gradcam=True)
 
+            # Test forward dummy
+            recognizer.forward_dummy(imgs, softmax=False)
+            res = recognizer.forward_dummy(imgs, softmax=True)[0]
+            assert torch.min(res) >= 0
+            assert torch.max(res) <= 1
+
     else:
         losses = recognizer(imgs, gt_labels)
         assert isinstance(losses, dict)
@@ -51,6 +57,12 @@ def test_i3d():
         recognizer(imgs, gradcam=True)
         for one_img in img_list:
             recognizer(one_img, gradcam=True)
+
+        # Test forward dummy
+        recognizer.forward_dummy(imgs, softmax=False)
+        res = recognizer.forward_dummy(imgs, softmax=True)[0]
+        assert torch.min(res) >= 0
+        assert torch.max(res) <= 1
 
 
 def test_r2plus1d():

--- a/tools/pytorch2onnx.py
+++ b/tools/pytorch2onnx.py
@@ -109,6 +109,10 @@ def parse_args():
     parser.add_argument('--output-file', type=str, default='tmp.onnx')
     parser.add_argument('--opset-version', type=int, default=11)
     parser.add_argument(
+        '--softmax',
+        action='store_true',
+        help='wheter to add softmax layer at the end of recognizers')
+    parser.add_argument(
         '--verify',
         action='store_true',
         help='verify the onnx model output against pytorch output')
@@ -144,7 +148,8 @@ if __name__ == '__main__':
 
     # onnx.export does not support kwargs
     if hasattr(model, 'forward_dummy'):
-        model.forward = model.forward_dummy
+        from functools import partial
+        model.forward = partial(model.forward_dummy, softmax=args.softmax)
     elif hasattr(model, '_forward') and args.is_localizer:
         model.forward = model._forward
     else:

--- a/tools/pytorch2onnx.py
+++ b/tools/pytorch2onnx.py
@@ -109,10 +109,6 @@ def parse_args():
     parser.add_argument('--output-file', type=str, default='tmp.onnx')
     parser.add_argument('--opset-version', type=int, default=11)
     parser.add_argument(
-        '--softmax',
-        action='store_true',
-        help='wheter to add softmax layer at the end of recognizers')
-    parser.add_argument(
         '--verify',
         action='store_true',
         help='verify the onnx model output against pytorch output')
@@ -126,6 +122,10 @@ def parse_args():
         nargs='+',
         default=[1, 3, 8, 224, 224],
         help='input video size')
+    parser.add_argument(
+        '--softmax',
+        action='store_true',
+        help='wheter to add softmax layer at the end of recognizers')
     args = parser.parse_args()
     return args
 


### PR DESCRIPTION
## Description
Now the exported recognizer onnx model doesn't have a softmax layer. In order to get predictions in range `[0, 1]`, `--softmax` option is added to `pytorch2onnx.py`, to add a softmax layer at the end of recognizers.

## usage

```shell
python tools/pytorch2onnx.py $CONFIG_PATH $CHECKPOINT_PATH --shape $SHAPE --verify --softmax
```

## TODO
+ [x] codes
+ [x] docs
+ [x] unittest
+ [x] changelog

## Question
Why does `forward_dummy` return a tuple `(outs, )` instead of `outs`?