### PR TITLE
[Fix] Fix a bug in pytorch2onnx.py when `num_classes <= 4`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,8 @@
 
 **Bug and Typo Fixes**
 
+- Fix a bug in pytorch2onnx.py when `num_classes <= 4` ([#800](https://github.com/open-mmlab/mmaction2/pull/800))
+
 **ModelZoo**
 
 ### 0.13.0 (31/03/2021)

--- a/tests/test_utils/test_onnx.py
+++ b/tests/test_utils/test_onnx.py
@@ -16,7 +16,8 @@ class TestModel(nn.Module):
         return self.bn(self.conv(x))
 
     def forward_dummy(self, x):
-        return (self.forward(x), )
+        out = self.bn(self.conv(x))
+        return (out, )
 
 
 def test_onnx_exporting():
@@ -25,4 +26,6 @@ def test_onnx_exporting():
         model = TestModel()
         model = _convert_batchnorm(model)
         # test exporting
+        if hasattr(model, 'forward_dummy'):
+            model.forward = model.forward_dummy
         pytorch2onnx(model, (2, 1, 1, 1, 1), output_file=out_file, verify=True)

--- a/tests/test_utils/test_onnx.py
+++ b/tests/test_utils/test_onnx.py
@@ -25,4 +25,4 @@ def test_onnx_exporting():
         model = TestModel()
         model = _convert_batchnorm(model)
         # test exporting
-        pytorch2onnx(model, (1, 1, 1, 1, 1), output_file=out_file)
+        pytorch2onnx(model, (2, 1, 1, 1, 1), output_file=out_file, verify=True)

--- a/tools/pytorch2onnx.py
+++ b/tools/pytorch2onnx.py
@@ -94,8 +94,9 @@ def pytorch2onnx(model,
         onnx_result = sess.run(
             None, {net_feed_input[0]: input_tensor.detach().numpy()})[0]
         # only compare part of results
+        random_class = np.random.randint(pytorch_result.shape[1])
         assert np.allclose(
-            pytorch_result[:, 4], onnx_result[:, 4]
+            pytorch_result[:, random_class], onnx_result[:, random_class]
         ), 'The outputs are different between Pytorch and ONNX'
         print('The numerical values are same between Pytorch and ONNX')
 

--- a/tools/pytorch2onnx.py
+++ b/tools/pytorch2onnx.py
@@ -81,7 +81,7 @@ def pytorch2onnx(model,
 
         # check the numerical value
         # get pytorch output
-        pytorch_result = model(input_tensor)[0].detach().numpy()
+        pytorch_result = model(input_tensor).detach().numpy()
 
         # get onnx output
         input_all = [node.name for node in onnx_model.graph.input]

--- a/tools/pytorch2onnx.py
+++ b/tools/pytorch2onnx.py
@@ -81,7 +81,7 @@ def pytorch2onnx(model,
 
         # check the numerical value
         # get pytorch output
-        pytorch_result = model(input_tensor).detach().numpy()
+        pytorch_result = model(input_tensor)[0].detach().numpy()
 
         # get onnx output
         input_all = [node.name for node in onnx_model.graph.input]


### PR DESCRIPTION
When `num_classes <= 4`, `pytorch_result[:, 4]` will raise index out of range error.