### PR TITLE
Fix #534

### DIFF
--- a/tools/data/ava/cut_videos.sh
+++ b/tools/data/ava/cut_videos.sh
@@ -29,6 +29,6 @@ for video in $(ls -A1 -U ${IN_DATA_DIR}/*)
 do
   out_name="${OUT_DATA_DIR}/${video##*/}"
   if [ ! -f "${out_name}" ]; then
-    ffmpeg -ss 900 -t 901 -i "${video}" -strict experimental "${out_name}"
+    ffmpeg -ss 900 -t 901 -i "${video}" -r 30 -strict experimental "${out_name}"
   fi
 done


### PR DESCRIPTION
It seems that #576 haven't fixed #534 since it doesn't add `-r 30` after `-i`

Cut videos: ffmpeg
Extract frames: ffmpeg or opencv

#576 fix cut with ffmpeg + extract with ffmpeg
According to #806, cut with ffmpeg + extract with opencv couldn't work.
Will have a try