### PR TITLE
[Fix] Fix bug: Resume can not work.

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -137,7 +137,7 @@ def main():
 
     # log some basic info
     logger.info(f'Distributed training: {distributed}')
-    logger.info(f'Config: {cfg.text}')
+    logger.info(f'Config: {cfg.pretty_text}')
 
     # set random seeds
     if args.seed is not None:


### PR DESCRIPTION
The first line of cfg.text is the config filename, which will not be parsed by this line:
https://github.com/open-mmlab/mmcv/blob/de4f14e9cd547fb8bf886a362ad4f02a0be95141/mmcv/runner/base_runner.py#L346

Use cfg.pretty_text instead.