### PR TITLE
[Docs] fix typo for sthv1 data preparing

### DIFF
--- a/tools/data/sthv1/README.md
+++ b/tools/data/sthv1/README.md
@@ -86,7 +86,7 @@ bash extract_flow.sh
 
 ## Step 4. Encode Videos
 
-This part is **optional** if you only want to use RGB frames.
+This part is **optional** if you only want to use RGB videos.
 
 You can run the following script to encode videos.
 

--- a/tools/data/sthv1/README_zh-CN.md
+++ b/tools/data/sthv1/README_zh-CN.md
@@ -61,7 +61,7 @@ data = dict(
 
 ## 步骤 3. 抽取光流
 
-如果用户只想使用原 RGB 帧加载训练，则该部分是 **可选项**。
+如果用户只想使用原 RGB 视频加载训练，则该部分是 **可选项**。
 
 在抽取视频帧和光流之前，请参考 [安装指南](/docs_zh_CN/install.md) 安装 [denseflow](https://github.com/open-mmlab/denseflow)。
 


### PR DESCRIPTION
## Typo

Hi, I think the data preprocessing [step-4](https://github.com/open-mmlab/mmaction2/blob/master/tools/data/sthv1/README.md#L87-L97) for something-v1 is for video format input，so I fix the typos accordingly.