### PR TITLE
add metric_options to docs

### DIFF
--- a/docs/tutorials/1_config.md
+++ b/docs/tutorials/1_config.md
@@ -414,7 +414,7 @@ which is convenient to conduct various experiments.
     evaluation = dict(  # Config of evaluation during training
         interval=5,  # Interval to perform evaluation
         metrics=['top_k_accuracy', 'mean_class_accuracy'],  # Metrics to be performed
-        metric_options=dict(top_k_accuracy=dict(topk=(1, 3))), # Set top-k accuracy to 3
+        metric_options=dict(top_k_accuracy=dict(topk=(1, 3))), # Set top-k accuracy to 1 and 3
         save_best='top_k_accuracy')  # set `top_k_accuracy` as key indicator to save best checkpoint
     log_config = dict(  # Config to register logger hook
         interval=20,  # Interval to print the log

--- a/docs/tutorials/1_config.md
+++ b/docs/tutorials/1_config.md
@@ -414,6 +414,7 @@ which is convenient to conduct various experiments.
     evaluation = dict(  # Config of evaluation during training
         interval=5,  # Interval to perform evaluation
         metrics=['top_k_accuracy', 'mean_class_accuracy'],  # Metrics to be performed
+        metric_options=dict(top_k_accuracy=dict(topk=(1, 3))), # Set top-k accuracy to 3
         save_best='top_k_accuracy')  # set `top_k_accuracy` as key indicator to save best checkpoint
     log_config = dict(  # Config to register logger hook
         interval=20,  # Interval to print the log


### PR DESCRIPTION
## Motivation

By default after each epoch, evaluation is done for top-5 accuracy. It's possible to set this top-k accuracy but it's missing from the docs. One has to go to the [source code](https://mmaction2.readthedocs.io/en/latest/_modules/mmaction/datasets/base.html?highlight=top_k_accuracy#) in order to find out what to do.

## Modification

One-liner to document metric_options
