### PR TITLE
[Fix] Fix 806

### DIFF
--- a/tools/data/ava/README.md
+++ b/tools/data/ava/README.md
@@ -80,13 +80,7 @@ If you only want to play with RGB frames (since extracting optical flow can be t
 bash extract_rgb_frames.sh
 ```
 
-If you didn't install denseflow, you can still extract RGB frames using OpenCV by the following script, but it will keep the original size of the images.
-
-```shell
-bash extract_rgb_frames_opencv.sh
-```
-
-Or using ffmpeg to extract RGB frames by the following script.
+If you didn't install denseflow, you can still extract RGB frames using using ffmpeg to extract RGB frames by the following script.
 
 ```shell
 bash extract_rgb_frames_ffmpeg.sh

--- a/tools/data/ava/README.md
+++ b/tools/data/ava/README.md
@@ -80,7 +80,7 @@ If you only want to play with RGB frames (since extracting optical flow can be t
 bash extract_rgb_frames.sh
 ```
 
-If you didn't install denseflow, you can still extract RGB frames using using ffmpeg to extract RGB frames by the following script.
+If you didn't install denseflow, you can still extract RGB frames using ffmpeg by the following script.
 
 ```shell
 bash extract_rgb_frames_ffmpeg.sh

--- a/tools/data/ava/README_zh-CN.md
+++ b/tools/data/ava/README_zh-CN.md
@@ -66,19 +66,13 @@ mkdir /mnt/SSD/ava_extracted/
 ln -s /mnt/SSD/ava_extracted/ ../data/ava/rawframes/
 ```
 
-如果用户只使用 RGB 帧（由于光流提取非常耗时），可以考虑执行以下脚本，仅用 denseflow 提取 RGB 帧：
+如果用户只使用 RGB 帧（由于光流提取非常耗时），可执行以下脚本使用 denseflow 提取 RGB 帧：
 
 ```shell
 bash extract_rgb_frames.sh
 ```
 
-如果用户未安装 denseflow，以下脚本可以使用 OpenCV 进行 RGB 帧的提取，但视频原分辨率大小会被保留：
-
-```shell
-bash extract_rgb_frames_opencv.sh
-```
-
-或执行以下脚本，使用 ffmpeg 提取 RGB 帧：
+如果用户未安装 denseflow，可执行以下脚本使用 ffmpeg 提取 RGB 帧：
 
 ```shell
 bash extract_rgb_frames_ffmpeg.sh

--- a/tools/data/ava/extract_rgb_frames_opencv.sh
+++ b/tools/data/ava/extract_rgb_frames_opencv.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-cd ../
-python build_rawframes.py ../../data/ava/videos_15min/ ../../data/ava/rawframes/ --task rgb --level 1 --use-opencv --mixed-ext
-echo "Genearte raw frames (RGB only)"
-
-cd ava/


### PR DESCRIPTION
## Motivation
Fix #806 

[related comment](https://github.com/open-mmlab/mmaction2/issues/806#issuecomment-819959911)

> For ava, each video must have a fixed number(27030) of frames.
> It seems OpenCV cannot do that [opencv/opencv#9053 (comment)](https://github.com/opencv/opencv/issues/9053#issuecomment-404261402)
> 
> > It seems to me that the problem is that VideoCapture ignores all duplicate frames, while FFmpeg will return duplicates without issues
> 
> I would recommend that AVA dataset should not extract frames by OpenCV and we should remove related docs in tutorials.
> 
> For other dataset, there is no requirement on the number of frames for each video, so extracting frames by OpenCV is ok.

## Modification

Remove docs and script that extracting ava rgb frames by OpenCV