### PR TITLE
[fix] Correct the key name of  ‘eval_results’ dictionary for metric 'mmit_mean_average_precision'

### DIFF
--- a/mmaction/datasets/base.py
+++ b/mmaction/datasets/base.py
@@ -229,10 +229,12 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
                 ]
                 if metric == 'mean_average_precision':
                     mAP = mean_average_precision(results, gt_labels)
+                    eval_results['mean_average_precision'] = mAP
+                    log_msg = f'\nmean_average_precision\t{mAP:.4f}'
                 elif metric == 'mmit_mean_average_precision':
                     mAP = mmit_mean_average_precision(results, gt_labels)
-                eval_results['mean_average_precision'] = mAP
-                log_msg = f'\nmean_average_precision\t{mAP:.4f}'
+                    eval_results['mmit_mean_average_precision'] = mAP
+                    log_msg = f'\nmmit_mean_average_precision\t{mAP:.4f}'
                 print_log(log_msg, logger=logger)
                 continue
 


### PR DESCRIPTION
## Motivation

I was training my own multi-label classification dataset using metric ```mmit_mean_average_precision```, and a KeyError occurred:
```
KeyError: 'mean_average_precision'.
```
I found that the evaluation results of metric ```mmit_mean_average_precision```were stored in the dictionary ```eval_results```using a wrong key name ```mean_average_precision```, which is responsible for this error.

## Modification

Corrected the key name of dictionary ```eval_results```  in the file ```mmaction/datasets/base.py ```.
After this correction, the training process is running normally now.
