### PR TITLE
Support number counting for flow-wise filename template

### DIFF
--- a/configs/recognition/tsn/tsn_r50_320p_1x1x3_110e_kinetics400_flow.py
+++ b/configs/recognition/tsn/tsn_r50_320p_1x1x3_110e_kinetics400_flow.py
@@ -1,5 +1,9 @@
 _base_ = ['../../_base_/models/tsn_r50.py', '../../_base_/default_runtime.py']
 
+# model settings
+# ``in_channels`` should be 2 * clip_len
+model = dict(backbone=dict(in_channels=10))
+
 # dataset settings
 dataset_type = 'RawframeDataset'
 data_root = 'data/kinetics400/rawframes_train_320p'

--- a/configs/recognition/tsn/tsn_r50_320p_1x1x8_110e_kinetics400_flow.py
+++ b/configs/recognition/tsn/tsn_r50_320p_1x1x8_110e_kinetics400_flow.py
@@ -1,5 +1,9 @@
 _base_ = ['../../_base_/models/tsn_r50.py', '../../_base_/default_runtime.py']
 
+# model settings
+# ``in_channels`` should be 2 * clip_len
+model = dict(backbone=dict(in_channels=10))
+
 # dataset settings
 dataset_type = 'RawframeDataset'
 data_root = 'data/kinetics400/rawframes_train_320p'

--- a/configs/recognition/tsn/tsn_r50_320p_1x1x8_150e_activitynet_clip_flow.py
+++ b/configs/recognition/tsn/tsn_r50_320p_1x1x8_150e_activitynet_clip_flow.py
@@ -1,6 +1,7 @@
 _base_ = ['../../_base_/models/tsn_r50.py', '../../_base_/default_runtime.py']
 
 # model settings
+# ``in_channels`` should be 2 * clip_len
 model = dict(
     backbone=dict(in_channels=10),
     cls_head=dict(num_classes=200, dropout_ratio=0.8))

--- a/configs/recognition/tsn/tsn_r50_320p_1x1x8_150e_activitynet_video_flow.py
+++ b/configs/recognition/tsn/tsn_r50_320p_1x1x8_150e_activitynet_video_flow.py
@@ -1,6 +1,7 @@
 _base_ = ['../../_base_/models/tsn_r50.py', '../../_base_/default_runtime.py']
 
 # model settings
+# ``in_channels`` should be 2 * clip_len
 model = dict(
     backbone=dict(in_channels=10),
     cls_head=dict(num_classes=200, dropout_ratio=0.8))

--- a/demo/demo_gradcam.py
+++ b/demo/demo_gradcam.py
@@ -87,7 +87,6 @@ def build_inputs(model, video_path, use_frames=False):
         data = dict(
             frame_dir=video_path,
             total_frames=len(os.listdir(video_path)),
-            # assuming files in ``video_path`` are all named with ``filename_tmpl``  # noqa: E501
             label=-1,
             start_index=start_index,
             filename_tmpl=filename_tmpl,

--- a/tests/test_runtime/test_inference.py
+++ b/tests/test_runtime/test_inference.py
@@ -8,8 +8,10 @@ from mmaction.apis import inference_recognizer, init_recognizer
 
 video_config_file = 'configs/recognition/tsn/tsn_r50_video_inference_1x1x3_100e_kinetics400_rgb.py'  # noqa: E501
 frame_config_file = 'configs/recognition/tsn/tsn_r50_inference_1x1x3_100e_kinetics400_rgb.py'  # noqa: E501
+flow_frame_config_file = 'configs/recognition/tsn/tsn_r50_320p_1x1x3_110e_kinetics400_flow.py'  # noqa: E501
 label_path = 'demo/label_map_k400.txt'
 video_path = 'demo/demo.mp4'
+frames_path = 'tests/data/imgs'
 
 
 def test_init_recognizer():
@@ -43,7 +45,7 @@ def test_init_recognizer():
     assert model.cfg.model.backbone.pretrained is None
 
 
-def test_inference_recognizer():
+def test_video_inference_recognizer():
     if torch.cuda.is_available():
         device = 'cuda:0'
     else:
@@ -114,3 +116,66 @@ def test_inference_recognizer():
     assert feat['backbone'][0].size() == (1, 2048, 4, 8, 8)
     assert feat['backbone'][1].size() == (1, 256, 32, 8, 8)
     assert feat['cls_head'].size() == (1, 400)
+
+
+def test_frames_inference_recognizer():
+    if torch.cuda.is_available():
+        device = 'cuda:0'
+    else:
+        device = 'cpu'
+    rgb_model = init_recognizer(
+        frame_config_file, None, device, use_frames=True)
+    flow_model = init_recognizer(
+        flow_frame_config_file, None, device, use_frames=True)
+
+    with pytest.raises(RuntimeError):
+        # video path doesn't exist
+        inference_recognizer(rgb_model, 'missing_path', label_path)
+
+    with pytest.raises(RuntimeError):
+        # ``video_path`` should be consist with the ``use_frames``
+        inference_recognizer(
+            flow_model, frames_path, label_path, use_frames=False)
+
+    for ops in rgb_model.cfg.data.test.pipeline:
+        if ops['type'] in ('TenCrop', 'ThreeCrop'):
+            # Use CenterCrop to reduce memory in order to pass CI
+            ops['type'] = 'CenterCrop'
+            ops['crop_size'] = 224
+    for ops in flow_model.cfg.data.test.pipeline:
+        if ops['type'] in ('TenCrop', 'ThreeCrop'):
+            # Use CenterCrop to reduce memory in order to pass CI
+            ops['type'] = 'CenterCrop'
+            ops['crop_size'] = 224
+
+    top5_label = inference_recognizer(
+        rgb_model, frames_path, label_path, use_frames=True)
+    scores = [item[1] for item in top5_label]
+    assert len(top5_label) == 5
+    assert scores == sorted(scores, reverse=True)
+
+    _, feat = inference_recognizer(
+        flow_model,
+        frames_path,
+        label_path,
+        outputs=('backbone', 'cls_head'),
+        as_tensor=False,
+        use_frames=True)
+    assert isinstance(feat, dict)
+    assert 'backbone' in feat and 'cls_head' in feat
+    assert isinstance(feat['backbone'], np.ndarray)
+    assert isinstance(feat['cls_head'], np.ndarray)
+    assert feat['backbone'].shape == (25, 2048, 7, 7)
+    assert feat['cls_head'].shape == (1, 400)
+
+    _, feat = inference_recognizer(
+        rgb_model,
+        frames_path,
+        label_path,
+        use_frames=True,
+        outputs=('backbone.layer3', 'backbone.layer3.1.conv1'))
+    assert 'backbone.layer3.1.conv1' in feat and 'backbone.layer3' in feat
+    assert isinstance(feat['backbone.layer3.1.conv1'], torch.Tensor)
+    assert isinstance(feat['backbone.layer3'], torch.Tensor)
+    assert feat['backbone.layer3'].size() == (25, 1024, 14, 14)
+    assert feat['backbone.layer3.1.conv1'].size() == (25, 256, 14, 14)


### PR DESCRIPTION
## Motivation

1. As #904 and the following comment shows, for now, in `inference_recognizer` we assumes files in `video_path` are all named with filename_tmpl. This pr removes the above restriction.

https://github.com/open-mmlab/mmaction2/blob/f007661ab97b206bfb82ed7f815999e2d7964a9b/mmaction/apis/inference.py#L112

2. We have already provided a way to fix bug in #565. However, we haven't modified related configs. So if we train flow models with default config, this shape mismatch bug still occurs.

## Modification

1. For `inference_recognizer`, this pr count the file that filename format matches `filename_impl`, add some unittests. 
2. For TSN Flow configs, this pr modifies `in_channels` of `backbone`
