### PR TITLE
Improve check videos

### DIFF
--- a/demo/long_video_demo.py
+++ b/demo/long_video_demo.py
@@ -109,7 +109,7 @@ def show_results_video(result_queue,
     return text_info
 
 
-def get_results_json(result_queue, text_info, msg, thr, ind, out_json):
+def get_results_json(result_queue, text_info, thr, msg, ind, out_json):
     if len(result_queue) != 0:
         text_info = {}
         results = result_queue.popleft()
@@ -180,7 +180,7 @@ def show_results(model, data, label, args):
 
         if args.out_file.endswith('.json'):
             text_info, out_json = get_results_json(result_queue, text_info,
-                                                   msg, args.threshold, ind,
+                                                   args.threshold, msg, ind,
                                                    out_json)
         else:
             text_info = show_results_video(result_queue, text_info,

--- a/demo/long_video_demo.py
+++ b/demo/long_video_demo.py
@@ -109,7 +109,7 @@ def show_results_video(result_queue,
     return text_info
 
 
-def get_results_json(result_queue, text_info, thr, msg, ind, out_json):
+def get_results_json(result_queue, text_info, msg, thr, ind, out_json):
     if len(result_queue) != 0:
         text_info = {}
         results = result_queue.popleft()
@@ -180,7 +180,7 @@ def show_results(model, data, label, args):
 
         if args.out_file.endswith('.json'):
             text_info, out_json = get_results_json(result_queue, text_info,
-                                                   args.threshold, msg, ind,
+                                                   msg, args.threshold, ind,
                                                    out_json)
         else:
             text_info = show_results_video(result_queue, text_info,

--- a/tools/analysis/check_videos.py
+++ b/tools/analysis/check_videos.py
@@ -92,13 +92,6 @@ class RandomSampleFrames:
         return results
 
 
-def file_len(file):
-    with open(file) as f:
-        for i, _ in enumerate(f, 1):
-            pass
-    return i
-
-
 def _do_check_videos(lock, dataset, output_file, idx):
     try:
         dataset[idx]
@@ -150,8 +143,9 @@ if __name__ == '__main__':
     pool.join()
 
     if os.path.exists(args.output_file):
+        num_lines = sum(1 for _ in open(args.output_file))
         print(f'Checked {len(dataset)} videos, '
-              f'{file_len(args.output_file)} are corrupted/missing.')
+              f'{num_lines} are corrupted/missing.')
         if args.remove_corrupted_videos:
             print('Start deleting corrupted videos')
             cnt = 0

--- a/tools/analysis/check_videos.py
+++ b/tools/analysis/check_videos.py
@@ -2,7 +2,7 @@ import argparse
 import os
 import warnings
 from functools import partial
-from multiprocessing import Manager, Pool
+from multiprocessing import Manager, Pool, cpu_count
 
 import numpy as np
 from mmcv import Config, DictAction
@@ -37,16 +37,13 @@ def parse_args():
     parser.add_argument(
         '--split',
         default='train',
-        help='Dataset split, should be one of [train, val, test]')
+        choices=['train', 'val', 'test'],
+        help='Dataset split')
     parser.add_argument(
         '--decoder',
         default='decord',
+        choices=['decord', 'opencv', 'pyav'],
         help='Video decoder type, should be one of [decord, opencv, pyav]')
-    parser.add_argument(
-        '--num-processes',
-        type=int,
-        default=5,
-        help='Number of processes to check videos')
     parser.add_argument(
         '--remove-corrupted-videos',
         action='store_true',
@@ -90,6 +87,13 @@ class RandomSampleFrames:
         return results
 
 
+def file_len(file):
+    with open(file) as f:
+        for i, _ in enumerate(f, 1):
+            pass
+    return i
+
+
 def _do_check_videos(lock, dataset, output_file, idx):
     try:
         dataset[idx]
@@ -111,7 +115,6 @@ if __name__ == '__main__':
         opencv='OpenCV',
         pyav='PyAV',
     )
-    assert args.decoder in decoder_to_pipeline_prefix
 
     # read config file
     cfg = Config.fromfile(args.config)
@@ -132,7 +135,7 @@ if __name__ == '__main__':
     if os.path.exists(args.output_file):
         # remove exsiting output file
         os.remove(args.output_file)
-    pool = Pool(args.num_processes)
+    pool = Pool(cpu_count() - 1 or 1)
     lock = Manager().Lock()
     worker_fn = partial(_do_check_videos, lock, dataset, args.output_file)
     ids = range(len(dataset))
@@ -140,20 +143,20 @@ if __name__ == '__main__':
     # start checking
     for _ in tqdm(pool.imap_unordered(worker_fn, ids), total=len(ids)):
         pass
+    pool.close()
     pool.join()
 
-    # print results and release resources
-    pool.close()
-    with open(args.output_file, 'r') as f:
+    if os.path.exists(args.output_file):
         print(f'Checked {len(dataset)} videos, '
-              f'{len(f)} is/are corrupted/missing.')
-
-    if args.remove_corrupted_videos:
-        print('Start deleting corrupted videos')
-        cnt = 0
-        with open(args.output_file, 'r') as f:
-            for line in f:
-                if os.path.exists(line.strip()):
-                    os.remove(line.strip())
-                    cnt += 1
-        print(f'Delete {cnt} corrupted videos.')
+              f'{file_len(args.output_file)} are corrupted/missing.')
+        if args.remove_corrupted_videos:
+            print('Start deleting corrupted videos')
+            cnt = 0
+            with open(args.output_file, 'r') as f:
+                for line in f:
+                    if os.path.exists(line.strip()):
+                        os.remove(line.strip())
+                        cnt += 1
+            print(f'Deleted {cnt} corrupted videos.')
+    else:
+        print(f'Checked {len(dataset)} videos, ' 'none are corrupted/missing')

--- a/tools/analysis/check_videos.py
+++ b/tools/analysis/check_videos.py
@@ -107,10 +107,7 @@ if __name__ == '__main__':
     args = parse_args()
 
     decoder_to_pipeline_prefix = dict(
-        decord='Decord',
-        opencv='OpenCV',
-        pyav='PyAV',
-    )
+        decord='Decord', opencv='OpenCV', pyav='PyAV')
 
     # read config file
     cfg = Config.fromfile(args.config)

--- a/tools/analysis/check_videos.py
+++ b/tools/analysis/check_videos.py
@@ -45,6 +45,11 @@ def parse_args():
         choices=['decord', 'opencv', 'pyav'],
         help='Video decoder type, should be one of [decord, opencv, pyav]')
     parser.add_argument(
+        '--num-processes',
+        type=int,
+        default=(cpu_count() - 1 or 1),
+        help='Number of processes to check videos')
+    parser.add_argument(
         '--remove-corrupted-videos',
         action='store_true',
         help='Whether to delete all corrupted videos')
@@ -108,8 +113,6 @@ def _do_check_videos(lock, dataset, output_file, idx):
 if __name__ == '__main__':
     args = parse_args()
 
-    assert args.split in ['train', 'val', 'test']
-
     decoder_to_pipeline_prefix = dict(
         decord='Decord',
         opencv='OpenCV',
@@ -135,7 +138,7 @@ if __name__ == '__main__':
     if os.path.exists(args.output_file):
         # remove exsiting output file
         os.remove(args.output_file)
-    pool = Pool(cpu_count() - 1 or 1)
+    pool = Pool(args.num_processes)
     lock = Manager().Lock()
     worker_fn = partial(_do_check_videos, lock, dataset, args.output_file)
     ids = range(len(dataset))
@@ -159,4 +162,4 @@ if __name__ == '__main__':
                         cnt += 1
             print(f'Deleted {cnt} corrupted videos.')
     else:
-        print(f'Checked {len(dataset)} videos, ' 'none are corrupted/missing')
+        print(f'Checked {len(dataset)} videos, none are corrupted/missing')


### PR DESCRIPTION
There are some problems with the `check_videos.py` script. I didn't see any current PR or issues on it so made this one.
Also improved some minor stuff.

## Bugs
- [pool.join()](https://github.com/open-mmlab/mmaction2/blob/master/tools/check_videos.py#L143) was being called before [pool.close()](https://github.com/open-mmlab/mmaction2/blob/master/tools/check_videos.py#L146). It should be the other way around. This also leads to the following error:

```
Traceback (most recent call last):
  File "tools/check_videos.py", line 143, in <module>
    pool.join()
  File "/opt/conda/lib/python3.8/multiprocessing/pool.py", line 659, in join
    raise ValueError("Pool is still running")
ValueError: Pool is still running
```

- Getting file length
The current way, [len(f)](https://github.com/open-mmlab/mmaction2/blob/master/tools/check_videos.py#L149) doesn't work since objects don't have length. Corresponding error:

```
Traceback (most recent call last):
  File "tools/check_videos.py", line 148, in <module>
    print(f'Checked {len(dataset)} videos, '
TypeError: object of type '_io.TextIOWrapper' has no len()

```
Added a function to get file length.

- If no clips with problems were found then the script fails because no output file exists, e.g. [here](https://github.com/open-mmlab/mmaction2/blob/master/tools/check_videos.py#L147).
- Same thing as above for deleting corrupted clips when no output file exists


## Minor improvements
- Remove [num-processes](https://github.com/open-mmlab/mmaction2/blob/master/tools/check_videos.py#L46) as args and add instead all but one cpus for multiprocessing: `pool = Pool(cpu_count() - 1 or 1)`
- Add choices for args [here ](https://github.com/open-mmlab/mmaction2/blob/master/tools/check_videos.py#L42) and [here](https://github.com/open-mmlab/mmaction2/blob/master/tools/check_videos.py#L38)