### PR TITLE
[Fix] Fix --test-best failure due to 'eval_hook' wrong assignment

### DIFF
--- a/mmaction/apis/train.py
+++ b/mmaction/apis/train.py
@@ -150,8 +150,9 @@ def train_model(model,
         dataloader_setting = dict(dataloader_setting,
                                   **cfg.data.get('val_dataloader', {}))
         val_dataloader = build_dataloader(val_dataset, **dataloader_setting)
-        eval_hook = DistEvalHook if distributed else EvalHook
-        runner.register_hook(eval_hook(val_dataloader, **eval_cfg))
+        eval_hook = DistEvalHook(val_dataloader, **eval_cfg) if distributed \
+            else EvalHook(val_dataloader, **eval_cfg)
+        runner.register_hook(eval_hook)
 
     if cfg.resume_from:
         runner.resume(cfg.resume_from)


### PR DESCRIPTION
# Motivation
I successfully trained my own model, but the '--test-best' command failed, and I got the warning:
```bash
Warning: test_best set as True, but is not applicable (eval_hook.best_ckpt_path is None)

```

The log is illustrated below:
```bash
2021-07-02 20:50:59,190 - mmaction - INFO - Epoch [1][1380/1407]      lr: 5.000e-05, eta: 0:00:05, time: 0.209, data_time: 0.000, memory: 4292, top1_acc: 0.8551, top5_acc: 0.9902, loss_cls: 0.4914, loss: 0.4914, grad_norm: 6.8683
2021-07-02 20:51:03,350 - mmaction - INFO - Epoch [1][1400/1407]      lr: 5.000e-05, eta: 0:00:01, time: 0.208, data_time: 0.001, memory: 4292, top1_acc: 0.8766, top5_acc: 0.9922, loss_cls: 0.4400, loss: 0.4400, grad_norm: 6.0801
2021-07-02 20:51:05,010 - mmaction - INFO - Saving checkpoint at 1 epochs
[>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>] 10000/10000, 462.2 task/s, elapsed: 22s, ETA:     0s

2021-07-02 20:51:29,419 - mmaction - INFO - Evaluating top_k_accuracy ...
2021-07-02 20:51:29,438 - mmaction - INFO - 
top1_acc        0.8796
top3_acc        0.9787
top5_acc        0.9926
top10_acc       1.0000
2021-07-02 20:51:29,438 - mmaction - INFO - Evaluating mean_class_accuracy ...
2021-07-02 20:51:29,443 - mmaction - INFO - 
mean_acc        0.8796
2021-07-02 20:51:31,711 - mmaction - INFO - Now best checkpoint is saved as best_top1_acc_epoch_1.pth.
2021-07-02 20:51:31,712 - mmaction - INFO - Best top1_acc is 0.8796 at 1 epoch.
2021-07-02 20:51:31,714 - mmaction - INFO - Epoch(val) [1][1407]      top1_acc: 0.8796, top3_acc: 0.9787, top5_acc: 0.9926, top10_acc: 1.0000, mean_class_accuracy: 0.8796
2021-07-02 20:51:32,722 - mmaction - INFO - Warning: test_best set as True, but is not applicable (eval_hook.best_ckpt_path is None)
```
My training followed the following procedures
- I applied config ``configs/recognition/tsn/tsn_r50_video_1x1x8_100e_kinetics400_rgb.py`` to my own dataset.
- I enabled ``save_best`` in the config above:
```python
evaluation = dict(
    interval=1,
    metrics=['top_k_accuracy', 'mean_class_accuracy'],
    metric_options=dict(top_k_accuracy=dict(topk=(1, 3, 5, 10))),
    save_best='top1_acc')
```
- I typed the following command for training:
```bash
./tools/dist_train.sh configs/recognition/tsn/tsn_r50_video_1x1x8_100e_kinetics400_rgb.py 8 --validate --test-best
```

# Modification
The problem is in `` mmaction/apis/train.py``.
The code use ``eval_hook.best_ckpt_path`` to get best checkpoint path:
```python
# Line 168
if hasattr(eval_hook, 'best_ckpt_path'):
    best_ckpt_path = eval_hook.best_ckpt_path
```
However, ``eval_hook`` is assigned with a Hook Class:
```python
# Line 153
eval_hook = DistEvalHook if distributed else EvalHook
runner.register_hook(eval_hook(val_dataloader, **eval_cfg))
```
Hence here comes the fix:
```python
eval_hook = DistEvalHook(val_dataloader, **eval_cfg) if distributed \
            else EvalHook(val_dataloader, **eval_cfg)
runner.register_hook(eval_hook)
```