### PR TITLE
add --to-mp4 argument to resize_videos.py

### DIFF
--- a/tools/data/resize_videos.py
+++ b/tools/data/resize_videos.py
@@ -31,7 +31,7 @@ def resize_videos(vid_item):
                f'-vf {"mpdecimate," if args.remove_dup else ""}'
                f'scale=-2:{args.scale} '
                f'{"-vsync vfr" if args.remove_dup else ""} '
-               f'-c:v {"libvpx" if args.ext=='webm' else "libx264"} '
+               f'-c:v {"libvpx" if args.ext=="webm" else "libx264"} '
                f'{"-g 16" if args.dense else ""} '
                f'-an {out_full_path} -y')
     else:
@@ -39,7 +39,7 @@ def resize_videos(vid_item):
                f'-vf {"mpdecimate," if args.remove_dup else ""}'
                f'scale={args.scale}:-2 '
                f'{"-vsync vfr" if args.remove_dup else ""} '
-               f'-c:v {"libvpx" if args.ext=='webm' else "libx264"} '
+               f'-c:v {"libvpx" if args.ext=="webm" else "libx264"} '
                f'{"-g 16" if args.dense else ""} '
                f'-an {out_full_path} -y')
     os.popen(cmd)

--- a/tools/data/resize_videos.py
+++ b/tools/data/resize_videos.py
@@ -17,6 +17,7 @@ def resize_videos(vid_item):
         bool: Whether generate video cache successfully.
     """
     full_path, vid_path = vid_item
+    vid_path = vid_path.replace('.webm', '.mp4')
     out_full_path = osp.join(args.out_dir, vid_path)
     dir_name = osp.dirname(vid_path)
     out_dir = osp.join(args.out_dir, dir_name)
@@ -31,16 +32,14 @@ def resize_videos(vid_item):
                f'-vf {"mpdecimate," if args.remove_dup else ""}'
                f'scale=-2:{args.scale} '
                f'{"-vsync vfr" if args.remove_dup else ""} '
-               f'-c:v {"libvpx" if args.ext=="webm" else "libx264"} '
-               f'{"-g 16" if args.dense else ""} '
+               f'-c:v libx264 {"-g 16" if args.dense else ""} '
                f'-an {out_full_path} -y')
     else:
         cmd = (f'ffmpeg -hide_banner -loglevel error -i {full_path} '
                f'-vf {"mpdecimate," if args.remove_dup else ""}'
                f'scale={args.scale}:-2 '
                f'{"-vsync vfr" if args.remove_dup else ""} '
-               f'-c:v {"libvpx" if args.ext=="webm" else "libx264"} '
-               f'{"-g 16" if args.dense else ""} '
+               f'-c:v libx264 {"-g 16" if args.dense else ""} '
                f'-an {out_full_path} -y')
     os.popen(cmd)
     print(f'{vid_path} done')

--- a/tools/data/resize_videos.py
+++ b/tools/data/resize_videos.py
@@ -17,6 +17,7 @@ def resize_videos(vid_item):
         bool: Whether generate video cache successfully.
     """
     full_path, vid_path = vid_item
+    # Change the output video extension to .mp4 if '--to-mp4' flag is set
     if args.to_mp4:
         vid_path = vid_path.split('.')
         assert len(vid_path) == 2, f"Video path '{vid_path}' contain more than one dot"

--- a/tools/data/resize_videos.py
+++ b/tools/data/resize_videos.py
@@ -31,14 +31,16 @@ def resize_videos(vid_item):
                f'-vf {"mpdecimate," if args.remove_dup else ""}'
                f'scale=-2:{args.scale} '
                f'{"-vsync vfr" if args.remove_dup else ""} '
-               f'-c:v libx264 {"-g 16" if args.dense else ""} '
+               f'-c:v {"libvpx" if args.ext=='webm' else "libx264"} '
+               f'{"-g 16" if args.dense else ""} '
                f'-an {out_full_path} -y')
     else:
         cmd = (f'ffmpeg -hide_banner -loglevel error -i {full_path} '
                f'-vf {"mpdecimate," if args.remove_dup else ""}'
                f'scale={args.scale}:-2 '
                f'{"-vsync vfr" if args.remove_dup else ""} '
-               f'-c:v libx264 {"-g 16" if args.dense else ""} '
+               f'-c:v {"libvpx" if args.ext=='webm' else "libx264"} '
+               f'{"-g 16" if args.dense else ""} '
                f'-an {out_full_path} -y')
     os.popen(cmd)
     print(f'{vid_path} done')

--- a/tools/data/resize_videos.py
+++ b/tools/data/resize_videos.py
@@ -17,7 +17,10 @@ def resize_videos(vid_item):
         bool: Whether generate video cache successfully.
     """
     full_path, vid_path = vid_item
-    vid_path = vid_path.replace('.webm', '.mp4')
+    if args.to_mp4:
+        vid_path = vid_path.split('.')
+        assert len(vid_path) == 2, f"Video path '{vid_path}' contain more than one dot"
+        vid_path = vid_path[0] + '.mp4'
     out_full_path = osp.join(args.out_dir, vid_path)
     dir_name = osp.dirname(vid_path)
     out_dir = osp.join(args.out_dir, dir_name)
@@ -72,6 +75,10 @@ def parse_args():
         default='mp4',
         choices=['avi', 'mp4', 'webm', 'mkv'],
         help='video file extensions')
+    parser.add_argument(
+        '--to-mp4',
+        action='store_true',
+        help='whether to output videos in mp4 format')
     parser.add_argument(
         '--scale',
         type=int,


### PR DESCRIPTION
## Motivation

Current ``resize_videos.py`` doesn't support resizing **.webm** videos. 

1. It can be solved by change the ``-c:v libx264`` to ``-c:v libvpx``: https://github.com/open-mmlab/mmaction2/blob/cf15d56ca36ef5ad96463503f3935d8bb0b4c726/tools/data/resize_videos.py#L34

2. Or just outputting **.mp4** videos, which is what this PR does. 

I choose the second solution because I found writing **.mp4** files saved lots of time. BTW, it requires lots of **extra** time to write the resized videos (which run in the background) **after** the python script execution is finished.

## Modification

Add ``--to-mp4`` argument, to output .mp4 files.

## Others

I had tested it on the ActivityNet dataset, which contains .mkv, .webm abd .mp4 videos.