### PR TITLE
[Improvement] add option to keep tail frames

### DIFF
--- a/tests/test_data/test_pipelines/test_loadings/test_sampling.py
+++ b/tests/test_data/test_pipelines/test_loadings/test_sampling.py
@@ -26,6 +26,15 @@ class TestSampling(BaseTestLoading):
                 clip_len=3, frame_interval=1, num_clips=5, start_index=1)
             SampleFrames(**config)
 
+        # Sample Frame with tail Frames
+        video_result = copy.deepcopy(self.video_results)
+        frame_result = copy.deepcopy(self.frame_results)
+        config = dict(
+            clip_len=3, frame_interval=1, num_clips=5, keep_tail_frames=True)
+        sample_frames = SampleFrames(**config)
+        sample_frames(video_result)
+        sample_frames(frame_result)
+
         # Sample Frame with no temporal_jitter
         # clip_len=3, frame_interval=1, num_clips=5
         video_result = copy.deepcopy(self.video_results)


### PR DESCRIPTION
This PR enables `class SampleFrames` with ability to sample tail frames.

Test Codes

```python
from mmaction.datasets.pipelines import SampleFrames
from matplotlib import pyplot as plt
import numpy as np

f = dict(total_frames=1000, start_index=0)
s = SampleFrames(clip_len=1, num_clips=128, keep_tail_frames=True)

# Sample 1000 times
a = []
for i in range(1000):
    a.append(s(f)['frame_inds'])
a = np.stack(a)

# Count occurance of each index
u, counts = np.unique(a, return_counts=True)
b = []
for i in range(1000):
    try:
        b.append(counts[u.tolist().index(i)])
    except ValueError:
        b.append(0)

# Plot
plt.plot(b)
plt.show()
```

Results
![keep_tail_frames](https://user-images.githubusercontent.com/33949370/126660159-16303b04-15a7-47f9-a4bd-558f2c32696c.png)
