### PR TITLE
[Improvement] Refactor Inference API

### DIFF
--- a/demo/demo.py
+++ b/demo/demo.py
@@ -160,8 +160,7 @@ def main():
     cfg.merge_from_dict(args.cfg_options)
 
     # build the recognizer from a config file and checkpoint file/url
-    model = init_recognizer(
-        cfg, args.checkpoint, device=device, use_frames=args.use_frames)
+    model = init_recognizer(cfg, args.checkpoint, device=device)
 
     # e.g. use ('backbone', ) to return backbone feature
     output_layer_names = None
@@ -169,14 +168,13 @@ def main():
     # test a single video or rawframes of a single video
     if output_layer_names:
         results, returned_feature = inference_recognizer(
-            model,
-            args.video,
-            args.label,
-            use_frames=args.use_frames,
-            outputs=output_layer_names)
+            model, args.video, outputs=output_layer_names)
     else:
-        results = inference_recognizer(
-            model, args.video, args.label, use_frames=args.use_frames)
+        results = inference_recognizer(model, args.video)
+
+    labels = open(args.label).readlines()
+    labels = [x.strip() for x in labels]
+    results = [(labels[k[0]], k[1]) for k in results]
 
     print('The top-5 labels with corresponding scores are:')
     for result in results:

--- a/demo/demo_gradcam.py
+++ b/demo/demo_gradcam.py
@@ -174,8 +174,7 @@ def main():
     cfg.merge_from_dict(args.cfg_options)
 
     # build the recognizer from a config file and checkpoint file/url
-    model = init_recognizer(
-        cfg, args.checkpoint, device=device, use_frames=args.use_frames)
+    model = init_recognizer(cfg, args.checkpoint, device=device)
 
     inputs = build_inputs(model, args.video, use_frames=args.use_frames)
     gradcam = GradCAM(model, args.target_layer_name)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -152,6 +152,10 @@ labels = 'tools/data/kinetics/label_map_k400.txt'
 results = inference_recognizer(model, video, labels)
 
 # show the results
+labels = open('tools/data/kinetics/label_map_k400.txt').readlines()
+labels = [x.strip() for x in labels]
+results = [(labels[k[0]], k[1]) for k in results]
+
 print(f'The top-5 labels with corresponding scores are:')
 for result in results:
     print(f'{result[0]}: ', result[1])
@@ -181,6 +185,10 @@ labels = 'tools/data/kinetics/label_map_k400.txt'
 results = inference_recognizer(model, video, labels, use_frames=True)
 
 # show the results
+labels = open('tools/data/kinetics/label_map_k400.txt').readlines()
+labels = [x.strip() for x in labels]
+results = [(labels[k[0]], k[1]) for k in results]
+
 print(f'The top-5 labels with corresponding scores are:')
 for result in results:
     print(f'{result[0]}: ', result[1])
@@ -210,6 +218,10 @@ labels = 'tools/data/kinetics/label_map_k400.txt'
 results = inference_recognizer(model, video, labels)
 
 # show the results
+labels = open('tools/data/kinetics/label_map_k400.txt').readlines()
+labels = [x.strip() for x in labels]
+results = [(labels[k[0]], k[1]) for k in results]
+
 print(f'The top-5 labels with corresponding scores are:')
 for result in results:
     print(f'{result[0]}: ', result[1])

--- a/docs/install.md
+++ b/docs/install.md
@@ -249,5 +249,5 @@ device = torch.device(device)
 
 model = init_recognizer(config_file, device=device)
 # inference the demo video
-inference_recognizer(model, 'demo/demo.mp4', 'tools/data/kinetics/label_map_k400.txt')
+inference_recognizer(model, 'demo/demo.mp4')
 ```

--- a/docs_zh_CN/getting_started.md
+++ b/docs_zh_CN/getting_started.md
@@ -150,6 +150,10 @@ labels = 'tools/data/kinetics/label_map_k400.txt'
 results = inference_recognizer(model, video, labels)
 
 # 显示结果
+labels = open('tools/data/kinetics/label_map_k400.txt').readlines()
+labels = [x.strip() for x in labels]
+results = [(labels[k[0]], k[1]) for k in results]
+
 print(f'The top-5 labels with corresponding scores are:')
 for result in results:
     print(f'{result[0]}: ', result[1])
@@ -179,6 +183,10 @@ labels = 'tools/data/kinetics/label_map_k400.txt'
 results = inference_recognizer(model, video, labels, use_frames=True)
 
 # 显示结果
+labels = open('tools/data/kinetics/label_map_k400.txt').readlines()
+labels = [x.strip() for x in labels]
+results = [(labels[k[0]], k[1]) for k in results]
+
 print(f'The top-5 labels with corresponding scores are:')
 for result in results:
     print(f'{result[0]}: ', result[1])
@@ -207,7 +215,11 @@ video = 'https://www.learningcontainer.com/wp-content/uploads/2020/05/sample-mp4
 labels = 'tools/data/kinetics/label_map_k400.txt'
 results = inference_recognizer(model, video, labels)
 
-#  根据配置文件和检查点来建立模型
+# 显示结果
+labels = open('tools/data/kinetics/label_map_k400.txt').readlines()
+labels = [x.strip() for x in labels]
+results = [(labels[k[0]], k[1]) for k in results]
+
 print(f'The top-5 labels with corresponding scores are:')
 for result in results:
     print(f'{result[0]}: ', result[1])

--- a/docs_zh_CN/install.md
+++ b/docs_zh_CN/install.md
@@ -240,5 +240,5 @@ device = torch.device(device)
 
 model = init_recognizer(config_file, device=device)
 # 进行演示视频的推理
-inference_recognizer(model, 'demo/demo.mp4', 'tools/data/kinetics/label_map_k400.txt')
+inference_recognizer(model, 'demo/demo.mp4')
 ```

--- a/mmaction/apis/inference.py
+++ b/mmaction/apis/inference.py
@@ -5,6 +5,7 @@ import re
 from operator import itemgetter
 
 import mmcv
+import numpy as np
 import torch
 from mmcv.parallel import collate, scatter
 from mmcv.runner import load_checkpoint
@@ -37,13 +38,6 @@ def init_recognizer(config,
     elif not isinstance(config, mmcv.Config):
         raise TypeError('config must be a filename or Config object, '
                         f'but got {type(config)}')
-    if ((use_frames and config.dataset_type != 'RawframeDataset')
-            or (not use_frames and config.dataset_type != 'VideoDataset')):
-        input_type = 'rawframes' if use_frames else 'video'
-        raise RuntimeError('input data type should be consist with the '
-                           f'dataset type in config, but got input type '
-                           f"'{input_type}' and dataset type "
-                           f"'{config.dataset_type}'")
 
     # pretrained model is unnecessary since we directly load checkpoint later
     config.model.backbone.pretrained = None
@@ -57,21 +51,14 @@ def init_recognizer(config,
     return model
 
 
-def inference_recognizer(model,
-                         video_path,
-                         label_path,
-                         use_frames=False,
-                         outputs=None,
-                         as_tensor=True):
+def inference_recognizer(model, video, outputs=None, as_tensor=True):
     """Inference a video with the detector.
 
     Args:
         model (nn.Module): The loaded recognizer.
-        video_path (str): The video file path/url or the rawframes directory
-            path. If ``use_frames`` is set to True, it should be rawframes
-            directory path. Otherwise, it should be video file path.
-        label_path (str): The label file path.
-        use_frames (bool): Whether to use rawframes as input. Default:False.
+        video (str | dict | ndarray): The video file path / url or the
+            rawframes directory path / results dictionary (the input of
+            pipeline) / a 4D array T x H x W x 3 (The input video).
         outputs (list(str) | tuple(str) | str | None) : Names of layers whose
             outputs need to be returned, default: None.
         as_tensor (bool): Same as that in ``OutputHook``. Default: True.
@@ -81,15 +68,20 @@ def inference_recognizer(model,
         dict[torch.tensor | np.ndarray]:
             Output feature maps from layers specified in `outputs`.
     """
-    if not (osp.exists(video_path) or video_path.startswith('http')):
-        raise RuntimeError(f"'{video_path}' is missing")
-
-    if osp.isfile(video_path) and use_frames:
-        raise RuntimeError(
-            f"'{video_path}' is a video file, not a rawframe directory")
-    if osp.isdir(video_path) and not use_frames:
-        raise RuntimeError(
-            f"'{video_path}' is a rawframe directory, not a video file")
+    input_flag = None
+    if isinstance(video, dict):
+        input_flag = 'dict'
+    elif isinstance(video, np.ndarray):
+        assert len(video.shape) == 4, 'The shape should be T x H x W x C'
+        input_flag = 'array'
+    elif isinstance(video, str) and osp.exists(video):
+        if osp.isfile(video):
+            input_flag = 'video'
+        if osp.isdir(video):
+            input_flag = 'rawframes'
+    else:
+        raise RuntimeError('The type of argument video is not supported: '
+                           f'{type(video)}')
 
     if isinstance(outputs, str):
         outputs = (outputs, )
@@ -97,14 +89,29 @@ def inference_recognizer(model,
 
     cfg = model.cfg
     device = next(model.parameters()).device  # model device
-    # construct label map
-    with open(label_path, 'r') as f:
-        label = [line.strip() for line in f]
     # build the data pipeline
     test_pipeline = cfg.data.test.pipeline
-    test_pipeline = Compose(test_pipeline)
-    # prepare data
-    if use_frames:
+    # Alter data pipelines & prepare inputs
+    if input_flag == 'array':
+        modality_map = {2: 'Flow', 3: 'RGB'}
+        modality = modality_map.get(video.shape[-1])
+        data = dict(
+            total_frames=video.shape[0],
+            label=-1,
+            start_index=0,
+            array=video,
+            modality=modality)
+        for i in range(len(test_pipeline)):
+            if 'Decode' in test_pipeline[i]['type']:
+                test_pipeline[i] = dict(type='ArrayDecode')
+    if input_flag == 'video':
+        data = dict(filename=video, label=-1, start_index=0, modality='RGB')
+        if 'Init' not in test_pipeline[0]['type']:
+            test_pipeline = [dict(type='DecordInit')] + test_pipeline
+        for i in range(len(test_pipeline)):
+            if 'Decode' in test_pipeline[i]['type']:
+                test_pipeline[i] = dict(type='DecordDecode')
+    if input_flag == 'rawframes':
         filename_tmpl = cfg.data.test.get('filename_tmpl', 'img_{:05}.jpg')
         modality = cfg.data.test.get('modality', 'RGB')
         start_index = cfg.data.test.get('start_index', 1)
@@ -120,24 +127,24 @@ def inference_recognizer(model,
         total_frames = len(
             list(
                 filter(lambda x: re.match(pattern, x) is not None,
-                       os.listdir(video_path))))
-
+                       os.listdir(video))))
         data = dict(
-            frame_dir=video_path,
+            frame_dir=video,
             total_frames=total_frames,
             label=-1,
             start_index=start_index,
             filename_tmpl=filename_tmpl,
             modality=modality)
-    else:
-        start_index = cfg.data.test.get('start_index', 0)
-        data = dict(
-            filename=video_path,
-            label=-1,
-            start_index=start_index,
-            modality='RGB')
+        if 'Init' in test_pipeline[0]['type']:
+            test_pipeline = test_pipeline[1:]
+        for i in range(len(test_pipeline)):
+            if 'Decode' in test_pipeline[i]['type']:
+                test_pipeline[i] = dict(type='RawFrameDecode')
+
+    test_pipeline = Compose(test_pipeline)
     data = test_pipeline(data)
     data = collate([data], samples_per_gpu=1)
+
     if next(model.parameters()).is_cuda:
         # scatter to specified GPU
         data = scatter(data, [device])[0]
@@ -148,7 +155,8 @@ def inference_recognizer(model,
             scores = model(return_loss=False, **data)[0]
         returned_features = h.layer_outputs if outputs else None
 
-    score_tuples = tuple(zip(label, scores))
+    num_classes = scores.shape[-1]
+    score_tuples = tuple(zip(range(num_classes), scores))
     score_sorted = sorted(score_tuples, key=itemgetter(1), reverse=True)
 
     top5_label = score_sorted[:5]

--- a/mmaction/apis/inference.py
+++ b/mmaction/apis/inference.py
@@ -15,10 +15,7 @@ from mmaction.datasets.pipelines import Compose
 from mmaction.models import build_recognizer
 
 
-def init_recognizer(config,
-                    checkpoint=None,
-                    device='cuda:0',
-                    use_frames=False):
+def init_recognizer(config, checkpoint=None, device='cuda:0'):
     """Initialize a recognizer from config file.
 
     Args:
@@ -28,7 +25,6 @@ def init_recognizer(config,
             the model will not load any weights. Default: None.
         device (str | :obj:`torch.device`): The desired device of returned
             tensor. Default: 'cuda:0'.
-        use_frames (bool): Whether to use rawframes as input. Default:False.
 
     Returns:
         nn.Module: The constructed recognizer.

--- a/mmaction/apis/inference.py
+++ b/mmaction/apis/inference.py
@@ -88,6 +88,8 @@ def inference_recognizer(model, video, outputs=None, as_tensor=True):
     # build the data pipeline
     test_pipeline = cfg.data.test.pipeline
     # Alter data pipelines & prepare inputs
+    if input_flag == 'dict':
+        data = video
     if input_flag == 'array':
         modality_map = {2: 'Flow', 3: 'RGB'}
         modality = modality_map.get(video.shape[-1])

--- a/mmaction/apis/inference.py
+++ b/mmaction/apis/inference.py
@@ -48,7 +48,7 @@ def init_recognizer(config, checkpoint=None, device='cuda:0'):
 
 
 def inference_recognizer(model, video, outputs=None, as_tensor=True):
-    """Inference a video with the detector.
+    """Inference a video with the recognizer.
 
     Args:
         model (nn.Module): The loaded recognizer.

--- a/mmaction/apis/inference.py
+++ b/mmaction/apis/inference.py
@@ -106,6 +106,8 @@ def inference_recognizer(model, video, outputs=None, as_tensor=True):
         data = dict(filename=video, label=-1, start_index=0, modality='RGB')
         if 'Init' not in test_pipeline[0]['type']:
             test_pipeline = [dict(type='DecordInit')] + test_pipeline
+        else:
+            test_pipeline[0] = dict(type='DecordInit')
         for i in range(len(test_pipeline)):
             if 'Decode' in test_pipeline[i]['type']:
                 test_pipeline[i] = dict(type='DecordDecode')

--- a/mmaction/apis/inference.py
+++ b/mmaction/apis/inference.py
@@ -70,6 +70,8 @@ def inference_recognizer(model, video, outputs=None, as_tensor=True):
     elif isinstance(video, np.ndarray):
         assert len(video.shape) == 4, 'The shape should be T x H x W x C'
         input_flag = 'array'
+    elif isinstance(video, str) and video.startswith('http'):
+        input_flag = 'video'
     elif isinstance(video, str) and osp.exists(video):
         if osp.isfile(video):
             input_flag = 'video'
@@ -105,12 +107,12 @@ def inference_recognizer(model, video, outputs=None, as_tensor=True):
     if input_flag == 'video':
         data = dict(filename=video, label=-1, start_index=0, modality='RGB')
         if 'Init' not in test_pipeline[0]['type']:
-            test_pipeline = [dict(type='DecordInit')] + test_pipeline
+            test_pipeline = [dict(type='OpenCVInit')] + test_pipeline
         else:
-            test_pipeline[0] = dict(type='DecordInit')
+            test_pipeline[0] = dict(type='OpenCVInit')
         for i in range(len(test_pipeline)):
             if 'Decode' in test_pipeline[i]['type']:
-                test_pipeline[i] = dict(type='DecordDecode')
+                test_pipeline[i] = dict(type='OpenCVDecode')
     if input_flag == 'rawframes':
         filename_tmpl = cfg.data.test.get('filename_tmpl', 'img_{:05}.jpg')
         modality = cfg.data.test.get('modality', 'RGB')

--- a/mmaction/apis/inference.py
+++ b/mmaction/apis/inference.py
@@ -70,6 +70,9 @@ def inference_recognizer(model, video, outputs=None, as_tensor=True):
     elif isinstance(video, np.ndarray):
         assert len(video.shape) == 4, 'The shape should be T x H x W x C'
         input_flag = 'array'
+        raise NotImplementedError(f'The input type {input_flag} is not '
+                                  'supported yet, this is an interface '
+                                  'reserved for torchserve. ')
     elif isinstance(video, str) and video.startswith('http'):
         input_flag = 'video'
     elif isinstance(video, str) and osp.exists(video):

--- a/mmaction/apis/inference.py
+++ b/mmaction/apis/inference.py
@@ -2,6 +2,7 @@
 import os
 import os.path as osp
 import re
+import warnings
 from operator import itemgetter
 
 import mmcv
@@ -15,7 +16,7 @@ from mmaction.datasets.pipelines import Compose
 from mmaction.models import build_recognizer
 
 
-def init_recognizer(config, checkpoint=None, device='cuda:0'):
+def init_recognizer(config, checkpoint=None, device='cuda:0', **kwargs):
     """Initialize a recognizer from config file.
 
     Args:
@@ -29,6 +30,11 @@ def init_recognizer(config, checkpoint=None, device='cuda:0'):
     Returns:
         nn.Module: The constructed recognizer.
     """
+    if 'use_frames' in kwargs:
+        warnings.warn('The argument `use_frames` is deprecated PR #1191. '
+                      'Now you can use models trained with frames or videos '
+                      'arbitrarily. ')
+
     if isinstance(config, str):
         config = mmcv.Config.fromfile(config)
     elif not isinstance(config, mmcv.Config):
@@ -47,7 +53,7 @@ def init_recognizer(config, checkpoint=None, device='cuda:0'):
     return model
 
 
-def inference_recognizer(model, video, outputs=None, as_tensor=True):
+def inference_recognizer(model, video, outputs=None, as_tensor=True, **kwargs):
     """Inference a video with the recognizer.
 
     Args:
@@ -64,6 +70,15 @@ def inference_recognizer(model, video, outputs=None, as_tensor=True):
         dict[torch.tensor | np.ndarray]:
             Output feature maps from layers specified in `outputs`.
     """
+    if 'use_frames' in kwargs:
+        warnings.warn('The argument `use_frames` is deprecated PR #1191. '
+                      'Now you can use models trained with frames or videos '
+                      'arbitrarily. ')
+    if 'label_path' in kwargs:
+        warnings.warn('The argument `use_frames` is deprecated PR #1191. '
+                      'Now the label file is not needed in '
+                      'inference_recognizer. ')
+
     input_flag = None
     if isinstance(video, dict):
         input_flag = 'dict'

--- a/tests/test_runtime/test_inference.py
+++ b/tests/test_runtime/test_inference.py
@@ -10,7 +10,6 @@ from mmaction.apis import inference_recognizer, init_recognizer
 video_config_file = 'configs/recognition/tsn/tsn_r50_video_inference_1x1x3_100e_kinetics400_rgb.py'  # noqa: E501
 frame_config_file = 'configs/recognition/tsn/tsn_r50_inference_1x1x3_100e_kinetics400_rgb.py'  # noqa: E501
 flow_frame_config_file = 'configs/recognition/tsn/tsn_r50_320p_1x1x3_110e_kinetics400_flow.py'  # noqa: E501
-label_path = 'tools/data/kinetics/label_map_k400.txt'
 video_path = 'demo/demo.mp4'
 frames_path = 'tests/data/imgs'
 
@@ -19,14 +18,6 @@ def test_init_recognizer():
     with pytest.raises(TypeError):
         # config must be a filename or Config object
         init_recognizer(dict(config_file=None))
-
-    with pytest.raises(RuntimeError):
-        # input data type should be consist with the dataset type
-        init_recognizer(frame_config_file)
-
-    with pytest.raises(RuntimeError):
-        # input data type should be consist with the dataset type
-        init_recognizer(video_config_file, use_frames=True)
 
     if torch.cuda.is_available():
         device = 'cuda:0'
@@ -55,32 +46,20 @@ def test_video_inference_recognizer():
 
     with pytest.raises(RuntimeError):
         # video path doesn't exist
-        inference_recognizer(model, 'missing.mp4', label_path)
-
-    with pytest.raises(RuntimeError):
-        # ``video_path`` should be consist with the ``use_frames``
-        inference_recognizer(model, video_path, label_path, use_frames=True)
-
-    with pytest.raises(RuntimeError):
-        # ``video_path`` should be consist with the ``use_frames``
-        inference_recognizer(model, 'demo/', label_path)
+        inference_recognizer(model, 'missing.mp4')
 
     for ops in model.cfg.data.test.pipeline:
         if ops['type'] in ('TenCrop', 'ThreeCrop'):
             # Use CenterCrop to reduce memory in order to pass CI
             ops['type'] = 'CenterCrop'
 
-    top5_label = inference_recognizer(model, video_path, label_path)
+    top5_label = inference_recognizer(model, video_path)
     scores = [item[1] for item in top5_label]
     assert len(top5_label) == 5
     assert scores == sorted(scores, reverse=True)
 
     _, feat = inference_recognizer(
-        model,
-        video_path,
-        label_path,
-        outputs=('backbone', 'cls_head'),
-        as_tensor=False)
+        model, video_path, outputs=('backbone', 'cls_head'), as_tensor=False)
     assert isinstance(feat, dict)
     assert 'backbone' in feat and 'cls_head' in feat
     assert isinstance(feat['backbone'], np.ndarray)
@@ -91,7 +70,6 @@ def test_video_inference_recognizer():
     _, feat = inference_recognizer(
         model,
         video_path,
-        label_path,
         outputs=('backbone.layer3', 'backbone.layer3.1.conv1'))
     assert 'backbone.layer3.1.conv1' in feat and 'backbone.layer3' in feat
     assert isinstance(feat['backbone.layer3.1.conv1'], torch.Tensor)
@@ -108,7 +86,7 @@ def test_video_inference_recognizer():
         if ops['type'] == 'SampleFrames':
             ops['num_clips'] = 1
     _, feat = inference_recognizer(
-        sf_model, video_path, label_path, outputs=('backbone', 'cls_head'))
+        sf_model, video_path, outputs=('backbone', 'cls_head'))
     assert isinstance(feat, dict) and isinstance(feat['backbone'], tuple)
     assert 'backbone' in feat and 'cls_head' in feat
     assert len(feat['backbone']) == 2
@@ -124,19 +102,12 @@ def test_frames_inference_recognizer():
         device = 'cuda:0'
     else:
         device = 'cpu'
-    rgb_model = init_recognizer(
-        frame_config_file, None, device, use_frames=True)
-    flow_model = init_recognizer(
-        flow_frame_config_file, None, device, use_frames=True)
+    rgb_model = init_recognizer(frame_config_file, None, device)
+    flow_model = init_recognizer(flow_frame_config_file, None, device)
 
     with pytest.raises(RuntimeError):
         # video path doesn't exist
-        inference_recognizer(rgb_model, 'missing_path', label_path)
-
-    with pytest.raises(RuntimeError):
-        # ``video_path`` should be consist with the ``use_frames``
-        inference_recognizer(
-            flow_model, frames_path, label_path, use_frames=False)
+        inference_recognizer(rgb_model, 'missing_path')
 
     for ops in rgb_model.cfg.data.test.pipeline:
         if ops['type'] in ('TenCrop', 'ThreeCrop'):
@@ -149,8 +120,7 @@ def test_frames_inference_recognizer():
             ops['type'] = 'CenterCrop'
             ops['crop_size'] = 224
 
-    top5_label = inference_recognizer(
-        rgb_model, frames_path, label_path, use_frames=True)
+    top5_label = inference_recognizer(rgb_model, frames_path)
     scores = [item[1] for item in top5_label]
     assert len(top5_label) == 5
     assert scores == sorted(scores, reverse=True)
@@ -158,10 +128,8 @@ def test_frames_inference_recognizer():
     _, feat = inference_recognizer(
         flow_model,
         frames_path,
-        label_path,
         outputs=('backbone', 'cls_head'),
-        as_tensor=False,
-        use_frames=True)
+        as_tensor=False)
     assert isinstance(feat, dict)
     assert 'backbone' in feat and 'cls_head' in feat
     assert isinstance(feat['backbone'], np.ndarray)
@@ -172,9 +140,8 @@ def test_frames_inference_recognizer():
     _, feat = inference_recognizer(
         rgb_model,
         frames_path,
-        label_path,
-        use_frames=True,
         outputs=('backbone.layer3', 'backbone.layer3.1.conv1'))
+
     assert 'backbone.layer3.1.conv1' in feat and 'backbone.layer3' in feat
     assert isinstance(feat['backbone.layer3.1.conv1'], torch.Tensor)
     assert isinstance(feat['backbone.layer3'], torch.Tensor)


### PR DESCRIPTION
Motivation:
1. More flexible inference: The dataset type of the config and actual data format does not need to match
2. More modalities: Support skeleton-based
3. Flexible API: Can take path str, dictionary, or numpy array (to support torch serve) as inputs. 

@dreamerlin, @gengenkai  Please leave some comments if you have more ideas. 
