### PR TITLE
[Fix] switch the default value of persistent_workers to False

### DIFF
--- a/mmaction/apis/train.py
+++ b/mmaction/apis/train.py
@@ -48,6 +48,7 @@ def train_model(model,
     dataloader_setting = dict(
         videos_per_gpu=cfg.data.get('videos_per_gpu', 1),
         workers_per_gpu=cfg.data.get('workers_per_gpu', 1),
+        persistent_workers=cfg.data.get('persistent_workers', False),
         num_gpus=len(cfg.gpu_ids),
         dist=distributed,
         seed=cfg.seed)
@@ -129,6 +130,7 @@ def train_model(model,
         dataloader_setting = dict(
             videos_per_gpu=cfg.data.get('videos_per_gpu', 1),
             workers_per_gpu=1,  # save memory and time
+            persistent_workers=cfg.data.get('persistent_workers', False),
             num_gpus=len(cfg.gpu_ids),
             dist=distributed,
             seed=cfg.seed)
@@ -144,6 +146,7 @@ def train_model(model,
         dataloader_setting = dict(
             videos_per_gpu=cfg.data.get('videos_per_gpu', 1),
             workers_per_gpu=cfg.data.get('workers_per_gpu', 1),
+            persistent_workers=cfg.data.get('persistent_workers', False),
             # cfg.gpus will be ignored if distributed
             num_gpus=len(cfg.gpu_ids),
             dist=distributed,
@@ -190,6 +193,7 @@ def train_model(model,
         dataloader_setting = dict(
             videos_per_gpu=cfg.data.get('videos_per_gpu', 1),
             workers_per_gpu=cfg.data.get('workers_per_gpu', 1),
+            persistent_workers=cfg.data.get('persistent_workers', False),
             num_gpus=len(cfg.gpu_ids),
             dist=distributed,
             shuffle=False)

--- a/mmaction/datasets/builder.py
+++ b/mmaction/datasets/builder.py
@@ -49,7 +49,7 @@ def build_dataloader(dataset,
                      seed=None,
                      drop_last=False,
                      pin_memory=True,
-                     persistent_workers=True,
+                     persistent_workers=False,
                      **kwargs):
     """Build PyTorch DataLoader.
 
@@ -76,7 +76,7 @@ def build_dataloader(dataset,
             the worker processes after a dataset has been consumed once.
             This allows to maintain the workers Dataset instances alive.
             The argument also has effect in PyTorch>=1.8.0.
-            Default: True
+            Default: False
         kwargs (dict, optional): Any keyword argument to be used to initialize
             DataLoader.
 

--- a/mmaction/datasets/pipelines/__init__.py
+++ b/mmaction/datasets/pipelines/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) OpenMMLab. All rights reserved.d
+# Copyright (c) OpenMMLab. All rights reserved.
 from .augmentations import (AudioAmplify, CenterCrop, ColorJitter, Flip, Fuse,
                             Imgaug, MelSpectrogram, MultiScaleCrop, Normalize,
                             PytorchVideoTrans, RandomCrop, RandomRescale,

--- a/mmaction/datasets/pipelines/__init__.py
+++ b/mmaction/datasets/pipelines/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) OpenMMLab. All rights reserved.
+# Copyright (c) OpenMMLab. All rights reserved.d
 from .augmentations import (AudioAmplify, CenterCrop, ColorJitter, Flip, Fuse,
                             Imgaug, MelSpectrogram, MultiScaleCrop, Normalize,
                             PytorchVideoTrans, RandomCrop, RandomRescale,

--- a/tools/analysis/bench_processing.py
+++ b/tools/analysis/bench_processing.py
@@ -45,6 +45,7 @@ def main():
         dataset,
         videos_per_gpu=cfg.data.videos_per_gpu,
         workers_per_gpu=0,
+        persistent_workers=False,
         num_gpus=1,
         dist=False)
 

--- a/tools/analysis/benchmark.py
+++ b/tools/analysis/benchmark.py
@@ -43,6 +43,7 @@ def main():
         dataset,
         videos_per_gpu=1,
         workers_per_gpu=cfg.data.workers_per_gpu,
+        persistent_workers=cfg.data.get('persistent_workers', False),
         dist=False,
         shuffle=False)
 


### PR DESCRIPTION
If the default value of persistent_workers is True and cannot be configured in the config file.  You can not train with num_workers=0. 