### PR TITLE
fixed: conda clean -> conda install anaconda

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y git ninja-build libglib2.0-0 libsm6 lib
 RUN pip install mmcv-full==latest+torch1.6.0+cu101 -f https://download.openmmlab.com/mmcv/dist/index.html
 
 # Install MMAction2
-RUN conda clean --all
+RUN conda install anaconda
 RUN git clone https://github.com/open-mmlab/mmaction2.git /mmaction2
 WORKDIR /mmaction2
 RUN mkdir -p /mmaction2/data


### PR DESCRIPTION
I encount this error.

~~~console
2021-11-17T14:36:30 [✖ ERROR  1] ❯ docker build -f ./docker/Dockerfile -t mmaction2 .
[+] Building 30.0s (12/12) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                      1.6s
 => => transferring dockerfile: 38B                                                                                                                                                                                                                       0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                         1.6s
 => => transferring context: 2B                                                                                                                                                                                                                           0.0s
 => [internal] load metadata for docker.io/pytorch/pytorch:1.6.0-cuda10.1-cudnn7-devel                                                                                                                                                                    1.6s
 => [1/9] FROM docker.io/pytorch/pytorch:1.6.0-cuda10.1-cudnn7-devel@sha256:ccebb46f954b1d32a4700aaeae0e24bd68653f92c6f276a608bf592b660b63d7                                                                                                              0.0s
 => CACHED [2/9] RUN apt-get update && apt-get install -y git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 ffmpeg     && apt-get clean     && rm -rf /var/lib/apt/lists/*                                                                      0.0s
 => CACHED [3/9] RUN pip install mmcv-full==latest+torch1.6.0+cu101 -f https://download.openmmlab.com/mmcv/dist/index.html                                                                                                                                0.0s
 => CACHED [4/9] RUN conda clean --all                                                                                                                                                                                                                    0.0s
 => CACHED [5/9] RUN git clone https://github.com/open-mmlab/mmaction2.git /mmaction2                                                                                                                                                                     0.0s
 => CACHED [6/9] WORKDIR /mmaction2                                                                                                                                                                                                                       0.0s
 => CACHED [7/9] RUN mkdir -p /mmaction2/data                                                                                                                                                                                                             0.0s
 => CACHED [8/9] RUN pip install cython --no-cache-dir                                                                                                                                                                                                    0.0s
 => ERROR [9/9] RUN pip install --no-cache-dir -e .                                                                                                                                                                                                      26.8s
------
 > [9/9] RUN pip install --no-cache-dir -e .:
#12 0.759 Obtaining file:///mmaction2                                                                                                                                                                                                                          
#12 2.631 Collecting decord                                                                                                                                                                                                                                    
#12 2.726   Downloading decord-0.6.0-py3-none-manylinux2010_x86_64.whl (13.6 MB)                                                                                                                                                                               
#12 4.845 Collecting einops                                                                                                                                                                                                                                    
#12 4.872   Downloading einops-0.3.2-py3-none-any.whl (25 kB)
#12 5.154 Collecting matplotlib
#12 5.178   Downloading matplotlib-3.5.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl (11.2 MB)
#12 6.547 Requirement already satisfied: numpy in /opt/conda/lib/python3.7/site-packages (from mmaction2==0.20.0) (1.18.5)
#12 6.815 Collecting opencv-contrib-python
#12 6.833   Downloading opencv_contrib_python-4.5.4.58-cp37-cp37m-manylinux2014_x86_64.whl (66.5 MB)
#12 14.20 Requirement already satisfied: Pillow in /opt/conda/lib/python3.7/site-packages (from mmaction2==0.20.0) (7.2.0)
#12 14.49 Collecting scipy
#12 14.51   Downloading scipy-1.7.2-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl (38.2 MB)
#12 19.07 Collecting fonttools>=4.22.0
#12 19.10   Downloading fonttools-4.28.1-py3-none-any.whl (873 kB)
#12 19.42 Collecting kiwisolver>=1.0.1
#12 19.44   Downloading kiwisolver-1.3.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl (1.1 MB)
#12 19.68 Collecting pyparsing>=2.2.1
#12 19.70   Downloading pyparsing-3.0.6-py3-none-any.whl (97 kB)
#12 19.76 Collecting cycler>=0.10
#12 19.79   Downloading cycler-0.11.0-py3-none-any.whl (6.4 kB)
#12 19.87 Collecting packaging>=20.0
#12 19.89   Downloading packaging-21.2-py3-none-any.whl (40 kB)
#12 19.97 Collecting python-dateutil>=2.7
#12 19.99   Downloading python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
#12 20.15 Collecting setuptools-scm>=4
#12 20.17   Downloading setuptools_scm-6.3.2-py3-none-any.whl (33 kB)
#12 20.19 Requirement already satisfied: six>=1.5 in /opt/conda/lib/python3.7/site-packages (from python-dateutil>=2.7->matplotlib->mmaction2==0.20.0) (1.14.0)
#12 20.24 Collecting tomli>=1.0.0
#12 20.27   Downloading tomli-1.2.2-py3-none-any.whl (12 kB)
#12 20.29 Requirement already satisfied: setuptools in /opt/conda/lib/python3.7/site-packages (from setuptools-scm>=4->matplotlib->mmaction2==0.20.0) (46.4.0.post20200518)
#12 20.48 ERROR: packaging 21.2 has requirement pyparsing<3,>=2.0.2, but you'll have pyparsing 3.0.6 which is incompatible.
#12 20.48 Installing collected packages: decord, einops, fonttools, kiwisolver, pyparsing, cycler, packaging, python-dateutil, tomli, setuptools-scm, matplotlib, opencv-contrib-python, scipy, mmaction2
#12 26.19   Running setup.py develop for mmaction2
#12 26.35     ERROR: Command errored out with exit status 1:
#12 26.35      command: /opt/conda/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/mmaction2/setup.py'"'"'; __file__='"'"'/mmaction2/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' develop --no-deps
#12 26.35          cwd: /mmaction2/
#12 26.35     Complete output (23 lines):
#12 26.35     Traceback (most recent call last):
#12 26.35       File "<string>", line 1, in <module>
#12 26.35       File "/mmaction2/setup.py", line 187, in <module>
#12 26.35         zip_safe=False)
#12 26.35       File "/opt/conda/lib/python3.7/site-packages/setuptools/__init__.py", line 143, in setup
#12 26.35         _install_setup_requires(attrs)
#12 26.35       File "/opt/conda/lib/python3.7/site-packages/setuptools/__init__.py", line 132, in _install_setup_requires
#12 26.35         (k, v) for k, v in attrs.items()
#12 26.35       File "/opt/conda/lib/python3.7/site-packages/setuptools/dist.py", line 426, in __init__
#12 26.35         k: v for k, v in attrs.items()
#12 26.35       File "/opt/conda/lib/python3.7/distutils/dist.py", line 292, in __init__
#12 26.35         self.finalize_options()
#12 26.35       File "/opt/conda/lib/python3.7/site-packages/setuptools/dist.py", line 716, in finalize_options
#12 26.35         for ep in sorted(eps, key=by_order):
#12 26.35       File "/opt/conda/lib/python3.7/site-packages/setuptools/dist.py", line 715, in <lambda>
#12 26.35         eps = map(lambda e: e.load(), pkg_resources.iter_entry_points(group))
#12 26.35       File "/opt/conda/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2452, in load
#12 26.35         self.require(*args, **kwargs)
#12 26.35       File "/opt/conda/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2475, in require
#12 26.35         items = working_set.resolve(reqs, env, installer, extras=self.extras)
#12 26.35       File "/opt/conda/lib/python3.7/site-packages/pkg_resources/__init__.py", line 792, in resolve
#12 26.35         raise VersionConflict(dist, req).with_context(dependent_req)
#12 26.35     pkg_resources.ContextualVersionConflict: (pyparsing 3.0.6 (/opt/conda/lib/python3.7/site-packages), Requirement.parse('pyparsing<3,>=2.0.2'), {'packaging'})
#12 26.35     ----------------------------------------
#12 26.43 ERROR: Command errored out with exit status 1: /opt/conda/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/mmaction2/setup.py'"'"'; __file__='"'"'/mmaction2/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' develop --no-deps Check the logs for full command output.
------
executor failed running [/bin/sh -c pip install --no-cache-dir -e .]: exit code: 1
~~~

I fix anaconda env.
docker build is success.

## Motivation

docker build is failed.

## Modification

Dockerfile.

`conda clean`

to

`conda install anaconda`

## BC-breaking (Optional)

No.

## Use cases (Optional)

No.

## Checklist

1. Pre-commit or other linting tools should be used to fix the potential lint issues.
2. The modification should be covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation should be modified accordingly, like docstring or example tutorials.
