### PR TITLE
Fix bug that start_index is not used in RawFrameDecode

### DIFF
--- a/mmaction/datasets/ava_dataset.py
+++ b/mmaction/datasets/ava_dataset.py
@@ -65,7 +65,7 @@ class AVADataset(BaseDataset):
         start_index (int): Specify a start index for frames in consideration of
             different filename format. However, when taking videos as input,
             it should be set to 0, since frames loaded from videos count
-            from 0. Default: 1.
+            from 0. Default: 0.
         proposal_file (str): Path to the proposal file like
             ``ava_dense_proposals_{train, val}.FAIR.recall_93.9.pkl``.
             Default: None.

--- a/mmaction/datasets/ava_dataset.py
+++ b/mmaction/datasets/ava_dataset.py
@@ -62,6 +62,10 @@ class AVADataset(BaseDataset):
             Default: None.
         filename_tmpl (str): Template for each filename.
             Default: 'img_{:05}.jpg'.
+        start_index (int): Specify a start index for frames in consideration of
+            different filename format. However, when taking videos as input,
+            it should be set to 0, since frames loaded from videos count
+            from 0. Default: 1.
         proposal_file (str): Path to the proposal file like
             ``ava_dense_proposals_{train, val}.FAIR.recall_93.9.pkl``.
             Default: None.
@@ -97,6 +101,7 @@ class AVADataset(BaseDataset):
                  pipeline,
                  label_file=None,
                  filename_tmpl='img_{:05}.jpg',
+                 start_index=0,
                  proposal_file=None,
                  person_det_score_thr=0.9,
                  num_classes=81,
@@ -135,6 +140,7 @@ class AVADataset(BaseDataset):
             pipeline,
             data_prefix,
             test_mode,
+            start_index=start_index,
             modality=modality,
             num_classes=num_classes)
 

--- a/mmaction/datasets/pipelines/loading.py
+++ b/mmaction/datasets/pipelines/loading.py
@@ -449,9 +449,10 @@ class SampleAVAFrames(SampleFrames):
             -self.frame_interval // 2, (self.frame_interval + 1) // 2,
             size=self.clip_len)
         frame_inds = self._get_clips(center_index, skip_offsets, shot_info)
-        start_index = results['start_index']
-
-        results['frame_inds'] = np.array(frame_inds, dtype=np.int) + start_index
+        start_index = results.get('start_index', 0)
+        
+        frame_inds = np.array(frame_inds, dtype=np.int) + start_index
+        results['frame_inds'] = frame_inds
         results['clip_len'] = self.clip_len
         results['frame_interval'] = self.frame_interval
         results['num_clips'] = 1

--- a/mmaction/datasets/pipelines/loading.py
+++ b/mmaction/datasets/pipelines/loading.py
@@ -1278,7 +1278,10 @@ class RawFrameDecode:
         if results['frame_inds'].ndim != 1:
             results['frame_inds'] = np.squeeze(results['frame_inds'])
 
-        offset = results.get('offset', 0)
+        if 'offset' in results:
+            offset = results.get('offset', 0)
+        else:
+            offset = results.get('start_index', 0)
 
         cache = {}
         for i, frame_idx in enumerate(results['frame_inds']):

--- a/mmaction/datasets/pipelines/loading.py
+++ b/mmaction/datasets/pipelines/loading.py
@@ -450,7 +450,7 @@ class SampleAVAFrames(SampleFrames):
             size=self.clip_len)
         frame_inds = self._get_clips(center_index, skip_offsets, shot_info)
         start_index = results.get('start_index', 0)
-        
+
         frame_inds = np.array(frame_inds, dtype=np.int) + start_index
         results['frame_inds'] = frame_inds
         results['clip_len'] = self.clip_len

--- a/mmaction/datasets/pipelines/loading.py
+++ b/mmaction/datasets/pipelines/loading.py
@@ -449,8 +449,9 @@ class SampleAVAFrames(SampleFrames):
             -self.frame_interval // 2, (self.frame_interval + 1) // 2,
             size=self.clip_len)
         frame_inds = self._get_clips(center_index, skip_offsets, shot_info)
+        start_index = results['start_index']
 
-        results['frame_inds'] = np.array(frame_inds, dtype=np.int)
+        results['frame_inds'] = np.array(frame_inds, dtype=np.int) + start_index
         results['clip_len'] = self.clip_len
         results['frame_interval'] = self.frame_interval
         results['num_clips'] = 1
@@ -1278,10 +1279,7 @@ class RawFrameDecode:
         if results['frame_inds'].ndim != 1:
             results['frame_inds'] = np.squeeze(results['frame_inds'])
 
-        if 'offset' in results:
-            offset = results.get('offset', 0)
-        else:
-            offset = results.get('start_index', 0)
+        offset = results.get('offset', 0)
 
         cache = {}
         for i, frame_idx in enumerate(results['frame_inds']):

--- a/tests/test_data/test_datasets/test_ava_dataset.py
+++ b/tests/test_data/test_datasets/test_ava_dataset.py
@@ -130,7 +130,7 @@ class TestAVADataset:
 
         assert result['filename_tmpl'] == 'img_{:05}.jpg'
         assert result['modality'] == 'RGB'
-        assert result['start_index'] == 1
+        assert result['start_index'] == 0
         assert result['timestamp_start'] == 900
         assert result['timestamp_end'] == 1800
         assert_array_equal(result['proposals'],
@@ -152,7 +152,7 @@ class TestAVADataset:
         result = ava_dataset[0]
         assert result['filename_tmpl'] == 'img_{:05}.jpg'
         assert result['modality'] == 'RGB'
-        assert result['start_index'] == 1
+        assert result['start_index'] == 0
         assert result['timestamp_start'] == 900
         assert result['timestamp_end'] == 1800
 


### PR DESCRIPTION
according to https://github.com/open-mmlab/mmaction2/blob/2ff37975b9ea5851a071909c9847b89132c5f99d/docs/faq.md#data
start_index is used to set the offset. However, start_index is not used in SampleAVAFrames
https://github.com/open-mmlab/mmaction2/blob/28ac80cb1a/mmaction/datasets/pipelines/loading.py#L1278

#1277 