### PR TITLE
Fixed Issue #1382 and a Printout Bug

### DIFF
--- a/mmaction/core/evaluation/ava_utils.py
+++ b/mmaction/core/evaluation/ava_utils.py
@@ -123,7 +123,7 @@ def read_exclusions(exclusions_file):
     if exclusions_file:
         reader = csv.reader(exclusions_file)
     for row in reader:
-        assert len(row) == 2, 'Expected only 2 columns, got: ' + len(row)
+        assert len(row) == 2, f'Expected only 2 columns, got: {len(row)}'
         excluded.add(make_image_key(row[0], row[1]))
     return excluded
 

--- a/mmaction/core/evaluation/ava_utils.py
+++ b/mmaction/core/evaluation/ava_utils.py
@@ -123,7 +123,7 @@ def read_exclusions(exclusions_file):
     if exclusions_file:
         reader = csv.reader(exclusions_file)
     for row in reader:
-        assert len(row) == 2, 'Expected only 2 columns, got: ' + row
+        assert len(row) == 2, 'Expected only 2 columns, got: ' + len(row)
         excluded.add(make_image_key(row[0], row[1]))
     return excluded
 

--- a/mmaction/models/heads/fbo_head.py
+++ b/mmaction/models/heads/fbo_head.py
@@ -337,7 +337,9 @@ class FBOHead(nn.Module):
                  lfb_cfg,
                  fbo_cfg,
                  temporal_pool_type='avg',
-                 spatial_pool_type='max'):
+                 spatial_pool_type='max',
+                 pretrained=None,
+                 ):
         super().__init__()
         fbo_type = fbo_cfg.pop('type', 'non_local')
         assert fbo_type in FBOHead.fbo_dict

--- a/mmaction/models/heads/lfb_infer_head.py
+++ b/mmaction/models/heads/lfb_infer_head.py
@@ -31,12 +31,8 @@ class LFBInferHead(nn.Module):
             'max'. Default: 'max'.
     """
 
-    def __init__(self,
-                 lfb_prefix_path,
-                 dataset_mode='train',
-                 use_half_precision=True,
-                 temporal_pool_type='avg',
-                 spatial_pool_type='max'):
+    def __init__(
+        self, lfb_prefix_path, dataset_mode='train', use_half_precision=True, temporal_pool_type='avg', spatial_pool_type='max', pretrained=None):
         super().__init__()
         rank, _ = get_dist_info()
         if rank == 0:


### PR DESCRIPTION
## Motivation
As per Issue #1382, Spatio-Temporal Localisation using the LFB model was failing.
In addition, there was a slight bug in the printing of the assertion error when the exclusion file had too many (or too little) columns.

## Modification
 1. Added a `pretrained` argument (default None, and unused) to the `__init__()` of LFBInferHead
 2. Refactored the way the length of a row is displayed in `ava_utils.read_exclusions()`


