### PR TITLE
[Update] Infinite Sampler

### DIFF
--- a/mmaction/core/runner/__init__.py
+++ b/mmaction/core/runner/__init__.py
@@ -1,4 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from .infinite_runner import InfiniteEpochBasedRunner
 from .omnisource_runner import OmniSourceDistSamplerSeedHook, OmniSourceRunner
 
-__all__ = ['OmniSourceRunner', 'OmniSourceDistSamplerSeedHook']
+__all__ = [
+    'OmniSourceRunner', 'OmniSourceDistSamplerSeedHook',
+    'InfiniteEpochBasedRunner'
+]

--- a/mmaction/core/runner/infinite_runner.py
+++ b/mmaction/core/runner/infinite_runner.py
@@ -1,0 +1,47 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import time
+
+from mmcv.runner import EpochBasedRunner
+from mmcv.runner.builder import RUNNERS
+from torch.utils.data import DataLoader
+
+
+@RUNNERS.register_module()
+class InfiniteEpochBasedRunner(EpochBasedRunner):
+    """Epoch-based Runner supports dataloader with InfiniteSampler.
+
+    The workers of dataloader will re-initialize, when the iterator of
+    dataloader is created. InfiniteSampler is designed to avoid these time
+    consuming operations, since the iterator with InfiniteSampler will never
+    reach the end.
+    """
+
+    def train(self, data_loader: DataLoader, **kwargs) -> None:
+        self.model.train()
+        self.mode = 'train'
+        self.data_loader = data_loader
+        self._max_iters = self._max_epochs * len(self.data_loader)
+        self.call_hook('before_train_epoch')
+        time.sleep(2)  # Prevent possible deadlock during epoch transition
+
+        # To reuse the iterator, we only create iterator once and bind it
+        # with runner. In the next epoch, the iterator will be used against
+        if not hasattr(self, 'data_loader_iter'):
+            self.data_loader_iter = iter(self.data_loader)
+
+        # The InfiniteSampler will never reach the end, but we set the
+        # length of InfiniteSampler to the actual length of dataset.
+        # The length of dataloader is determined by the length of sampler,
+        # when the sampler is not None. Therefore, we can simply forward the
+        # whole dataset in a epoch by length of dataloader.
+
+        for i in range(len(self.data_loader)):
+            data_batch = next(self.data_loader_iter)
+            self._inner_iter = i
+            self.call_hook('before_train_iter')
+            self.run_iter(data_batch, train_mode=True, **kwargs)
+            self.call_hook('after_train_iter')
+            self._iter += 1
+
+        self.call_hook('after_train_epoch')
+        self._epoch += 1

--- a/mmaction/core/runner/omnisource_runner.py
+++ b/mmaction/core/runner/omnisource_runner.py
@@ -4,6 +4,7 @@ import warnings
 
 import mmcv
 from mmcv.runner import EpochBasedRunner, Hook
+from mmcv.runner.builder import RUNNERS
 from mmcv.runner.utils import get_host_info
 
 
@@ -28,6 +29,7 @@ class OmniSourceDistSamplerSeedHook(Hook):
                 data_loader.batch_sampler.sampler.set_epoch(runner.epoch)
 
 
+@RUNNERS.register_module()
 class OmniSourceRunner(EpochBasedRunner):
     """OmniSource Epoch-based Runner.
 

--- a/mmaction/datasets/samplers/__init__.py
+++ b/mmaction/datasets/samplers/__init__.py
@@ -1,5 +1,12 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .distributed_sampler import (ClassSpecificDistributedSampler,
                                   DistributedSampler)
+from .infinite_sampler import (DistributedInfiniteGroupSampler,
+                               DistributedInfiniteSampler,
+                               InfiniteGroupSampler, InfiniteSampler)
 
-__all__ = ['DistributedSampler', 'ClassSpecificDistributedSampler']
+__all__ = [
+    'DistributedSampler', 'ClassSpecificDistributedSampler', 'InfiniteSampler',
+    'InfiniteGroupSampler', 'DistributedInfiniteSampler',
+    'DistributedInfiniteGroupSampler'
+]

--- a/mmaction/datasets/samplers/infinite_sampler.py
+++ b/mmaction/datasets/samplers/infinite_sampler.py
@@ -1,0 +1,296 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import itertools
+import math
+from typing import Iterable, Iterator, Optional
+
+import numpy as np
+import torch
+from mmcv.runner import get_dist_info
+from torch.utils.data.sampler import Sampler
+
+
+class InfiniteSampler(Sampler):
+    """Return a infinite stream of index.
+
+    The length of sampler is set to the actual length of dataset, thus the
+    length of dataloader is still determined by the dataset. The
+    implementation logic is referred to
+    https://github.com/facebookresearch/detectron2/blob/main/detectron2/data/samplers/grouped_batch_sampler.py
+
+    Args:
+        dataset (Iterable): The dataset.
+        seed (int): Random seed. Default: 0.
+        shuffle (bool): Whether shuffle the dataset or not. Default: True.
+    """  # noqa: W605
+
+    def __init__(self,
+                 dataset: Iterable,
+                 seed: int = 0,
+                 shuffle: bool = True) -> None:
+        self.dataset = dataset
+        self.seed = seed if seed is not None else 0
+        self.shuffle = shuffle
+        self.size = len(dataset)
+        self.indices = self._indices()
+        self.epoch = 0
+
+    def _infinite_indices(self) -> Iterator:
+        """Infinitely yield a sequence of indices."""
+        g = torch.Generator()
+        g.manual_seed(self.seed)
+        while True:
+            if self.shuffle:
+                yield from torch.randperm(self.size, generator=g).tolist()
+            else:
+                yield from torch.arange(self.size).tolist()
+
+    def _indices(self) -> Iterator:
+        """Slice the infinite indices by rank."""
+        yield from itertools.islice(self._infinite_indices(), 0, None)
+
+    def __iter__(self) -> Iterator:
+        for idx in self.indices:
+            yield idx
+
+    def __len__(self) -> int:
+        """Length of dataset."""
+        # The length of sampler is set to the actual length of dataset, thus
+        # the length of dataloader is still determined by the dataset.
+        return self.size
+
+    def set_epoch(self, epoch: int) -> None:
+        self.epoch = epoch
+
+
+class InfiniteGroupSampler(Sampler):
+    """Similar to `InfiniteSampler`, but all indices in a batch should be in
+    the same group of flag.
+
+    The length of sampler is set to the actual length of dataset, thus the
+    length of dataloader is still determined by the dataset. The
+    implementation logic is referred to
+    https://github.com/facebookresearch/detectron2/blob/main/detectron2/data/samplers/grouped_batch_sampler.py
+
+    Args:
+        dataset (Iterable): The dataset.
+        samples_per_gpu (int): Number of training samples on each GPU, i.e.,
+            batch size of each GPU. Default: 1.
+        seed (int): Random seed. Default: 0.
+        shuffle (bool): Whether shuffle the indices of a dummy `epoch`, it
+            should be noted that `shuffle` can not guarantee that you can
+            generate sequential indices because it need to ensure
+            that all indices in a batch is in a group. Default: True.
+    """  # noqa: W605
+
+    def __init__(self,
+                 dataset: Iterable,
+                 samples_per_gpu: int = 1,
+                 seed: int = 0,
+                 shuffle: bool = True) -> None:
+        self.dataset = dataset
+        self.samples_per_gpu = samples_per_gpu
+        self.seed = seed if seed is not None else 0
+        self.shuffle = shuffle
+
+        assert hasattr(self.dataset, 'flag')
+        self.flag = self.dataset.flag
+        self.group_sizes = np.bincount(self.flag)
+        # buffer used to save indices of each group
+        self.buffer_per_group = {k: [] for k in range(len(self.group_sizes))}
+
+        self.size = len(dataset)
+        self.indices = self._indices_of_rank()
+        self.epoch = 0
+
+    def _infinite_indices(self) -> Iterator:
+        """Infinitely yield a sequence of indices."""
+        g = torch.Generator()
+        g.manual_seed(self.seed)
+        while True:
+            if self.shuffle:
+                yield from torch.randperm(self.size, generator=g).tolist()
+            else:
+                yield from torch.arange(self.size).tolist()
+
+    def _indices_of_rank(self) -> Iterator:
+        """Slice the infinite indices by rank."""
+        yield from itertools.islice(self._infinite_indices(), 0, None)
+
+    def __iter__(self) -> Iterator:
+        # once batch size is reached, yield the indices
+        for idx in self.indices:
+            flag = self.flag[idx]
+            group_buffer = self.buffer_per_group[flag]
+            group_buffer.append(idx)
+            if len(group_buffer) == self.samples_per_gpu:
+                for i in range(self.samples_per_gpu):
+                    yield group_buffer[i]
+                del group_buffer[:]
+
+    def __len__(self) -> int:
+        """Length of dataset."""
+        # The length of sampler is set to the actual length of dataset, thus
+        # the length of dataloader is still determined by the dataset.
+        return self.size
+
+    def set_epoch(self, epoch: int) -> None:
+        self.epoch = epoch
+
+
+class DistributedInfiniteSampler(Sampler):
+    """Similar to `InfiniteSampler` but in distributed version.
+
+    The length of sampler is set to the actual length of dataset, thus the
+    length of dataloader is still determined by the dataset. The
+    implementation logic is referred to
+    https://github.com/facebookresearch/detectron2/blob/main/detectron2/data/samplers/grouped_batch_sampler.py
+
+    Args:
+        dataset (Iterable): The dataset.
+        num_replicas (int | None): Number of processes participating in
+            distributed training. Default: None.
+        rank (int | None): Rank of current process. Default: None.
+        seed (int): Random seed. Default: 0.
+        shuffle (bool): Whether shuffle the dataset or not. Default: True.
+    """  # noqa: W605
+
+    def __init__(self,
+                 dataset: Iterable,
+                 num_replicas: Optional[int] = None,
+                 rank: Optional[int] = None,
+                 seed: int = 0,
+                 shuffle: bool = True) -> None:
+        _rank, _num_replicas = get_dist_info()
+        if num_replicas is None:
+            num_replicas = _num_replicas
+        if rank is None:
+            rank = _rank
+        self.rank = rank
+        self.num_replicas = num_replicas
+        self.dataset = dataset
+        self.seed = seed if seed is not None else 0
+        self.shuffle = shuffle
+        self.size = len(dataset)
+        self.indices = self._indices_of_rank()
+        self.epoch = 0
+
+    def _infinite_indices(self) -> Iterator:
+        """Infinitely yield a sequence of indices."""
+        g = torch.Generator()
+        g.manual_seed(self.seed)
+        while True:
+            if self.shuffle:
+                indices = []
+                for _ in range(self.num_replicas):
+                    indices += torch.randperm(self.size, generator=g).tolist()
+                yield from indices
+            else:
+                yield from torch.arange(self.size).tolist()
+
+    def _indices_of_rank(self) -> Iterator:
+        """Slice the infinite indices by rank."""
+        yield from itertools.islice(self._infinite_indices(), self.rank, None,
+                                    self.num_replicas)
+
+    def __iter__(self) -> Iterator:
+        for idx in self.indices:
+            yield idx
+
+    def __len__(self):
+        """return length of dataset."""
+        # The length of sampler is set to the actual length of dataset, thus
+        # the length of dataloader is still determined by the dataset.
+        return math.ceil(self.size / self.num_replicas)
+
+    def set_epoch(self, epoch: int) -> None:
+        self.epoch = epoch
+
+
+class DistributedInfiniteGroupSampler(Sampler):
+    """Similar to `InfiniteGroupSampler` but in distributed version.
+
+    The length of sampler is set to the actual length of dataset, thus the
+    length of dataloader is still determined by the dataset. The
+    implementation logic is referred to
+    https://github.com/facebookresearch/detectron2/blob/main/detectron2/data/samplers/grouped_batch_sampler.py
+
+    Args:
+        dataset (Iterable): The dataset.
+        samples_per_gpu (int): Number of training samples on each GPU, i.e.,
+            batch size of each GPU. Default: 1.
+        num_replicas (int | None): Number of processes participating in
+            distributed training. Default: None.
+        rank (int | None): Rank of current process. Default: None.
+        seed (int): Random seed. Default: 0.
+        shuffle (bool): Whether shuffle the indices of a dummy `epoch`, it
+            should be noted that `shuffle` can not guarantee that you can
+            generate sequential indices because it need to ensure
+            that all indices in a batch is in a group. Default: True.
+    """  # noqa: W605
+
+    def __init__(self,
+                 dataset: Iterable,
+                 samples_per_gpu: int = 1,
+                 num_replicas: Optional[int] = None,
+                 rank: Optional[int] = None,
+                 seed: int = 0,
+                 shuffle: bool = True) -> None:
+        _rank, _num_replicas = get_dist_info()
+        if num_replicas is None:
+            num_replicas = _num_replicas
+        if rank is None:
+            rank = _rank
+        self.rank = rank
+        self.num_replicas = num_replicas
+        self.dataset = dataset
+        self.samples_per_gpu = samples_per_gpu
+        self.seed = seed if seed is not None else 0
+        self.shuffle = shuffle
+
+        assert hasattr(self.dataset, 'flag')
+        self.flag = self.dataset.flag
+        self.group_sizes = np.bincount(self.flag)
+        # buffer used to save indices of each group
+        self.buffer_per_group = {k: [] for k in range(len(self.group_sizes))}
+
+        self.size = len(dataset)
+        self.indices = self._indices_of_rank()
+        self.epoch = 0
+
+    def _infinite_indices(self) -> Iterator:
+        """Infinitely yield a sequence of indices."""
+        g = torch.Generator()
+        g.manual_seed(self.seed)
+        while True:
+            if self.shuffle:
+                indices = []
+                for _ in range(self.num_replicas):
+                    indices += torch.randperm(self.size, generator=g).tolist()
+                yield from indices
+            else:
+                yield from torch.arange(self.size).tolist()
+
+    def _indices_of_rank(self) -> Iterator:
+        """Slice the infinite indices by rank."""
+        yield from itertools.islice(self._infinite_indices(), self.rank, None,
+                                    self.num_replicas)
+
+    def __iter__(self) -> Iterator:
+        # once batch size is reached, yield the indices
+        for idx in self.indices:
+            flag = self.flag[idx]
+            group_buffer = self.buffer_per_group[flag]
+            group_buffer.append(idx)
+            if len(group_buffer) == self.samples_per_gpu:
+                for i in range(self.samples_per_gpu):
+                    yield group_buffer[i]
+                del group_buffer[:]
+
+    def __len__(self) -> int:
+        """return length of dataset."""
+        # The length of sampler is set to the actual length of dataset, thus
+        # the length of dataloader is still determined by the dataset.
+        return math.ceil(self.size / self.num_replicas)
+
+    def set_epoch(self, epoch: int) -> None:
+        self.epoch = epoch

--- a/tests/test_data/test_sampler.py
+++ b/tests/test_data/test_sampler.py
@@ -1,8 +1,13 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import numpy as np
+import torch
 from torch.utils.data import DataLoader, Dataset
 
 from mmaction.datasets.samplers import (ClassSpecificDistributedSampler,
-                                        DistributedSampler)
+                                        DistributedInfiniteGroupSampler,
+                                        DistributedInfiniteSampler,
+                                        DistributedSampler,
+                                        InfiniteGroupSampler, InfiniteSampler)
 
 
 class MyDataset(Dataset):
@@ -94,3 +99,99 @@ def test_class_specific_distributed_sampler():
 
     assert len(batches) == 5
     assert sum([len(x['data']) for x in batches]) == 17
+
+
+class ExampleDataset(Dataset):
+
+    def __init__(self):
+        self.flag = np.array([0, 1], dtype=np.uint8)
+
+    def __getitem__(self, idx):
+        results = dict(img=torch.tensor([idx]), img_metas=dict(idx=idx))
+        return results
+
+    def __len__(self):
+        return 2
+
+
+class ExampleDataset2(Dataset):
+
+    def __init__(self):
+        self.flag = np.array([0, 1, 1, 1], dtype=np.uint8)
+
+    def __getitem__(self, idx):
+        results = dict(img=torch.tensor([idx]), img_metas=dict(idx=idx))
+        return results
+
+    def __len__(self):
+        return 4
+
+
+def test_infinite_sampler():
+    dataset = ExampleDataset()
+    sampler = InfiniteSampler(dataset=dataset, shuffle=False)
+    dataloader = DataLoader(
+        dataset=dataset, num_workers=0, sampler=sampler, batch_size=1)
+    dataloader_iter = iter(dataloader)
+    for i in range(5):
+        data = next(dataloader_iter)
+        assert 'img' in data
+        assert 'img_metas' in data
+
+
+def test_infinite_group_sampler():
+    dataset = ExampleDataset()
+    sampler = InfiniteGroupSampler(
+        dataset=dataset, shuffle=False, samples_per_gpu=2)
+    dataloader = DataLoader(
+        dataset=dataset, num_workers=0, sampler=sampler, batch_size=2)
+    dataloader_iter = iter(dataloader)
+    for i in range(5):
+        data = next(dataloader_iter)
+        assert torch.allclose(data['img_metas']['idx'][0],
+                              data['img_metas']['idx'][1])
+
+
+def test_dist_infinite_sampler():
+    dataset = ExampleDataset()
+    sampler = DistributedInfiniteSampler(
+        dataset=dataset, shuffle=False, num_replicas=2, rank=0)
+    dataloader = DataLoader(
+        dataset=dataset, num_workers=0, sampler=sampler, batch_size=1)
+    dataloader_iter = iter(dataloader)
+    for i in range(5):
+        data = next(dataloader_iter)
+        assert data['img'].item() == 0
+
+
+def test_dist_group_infinite_sampler():
+    dataset = ExampleDataset2()
+    sampler = DistributedInfiniteGroupSampler(
+        dataset=dataset,
+        shuffle=False,
+        num_replicas=2,
+        rank=0,
+        samples_per_gpu=2)
+    dataloader = DataLoader(
+        dataset=dataset, num_workers=0, sampler=sampler, batch_size=2)
+    dataloader_iter = iter(dataloader)
+    for i in range(5):
+        data = next(dataloader_iter)
+        if i % 2 == 0:
+            assert torch.allclose(data['img_metas']['idx'],
+                                  torch.tensor([0, 0]))
+        else:
+            assert torch.allclose(data['img_metas']['idx'],
+                                  torch.tensor([2, 2]))
+    sampler = DistributedInfiniteGroupSampler(
+        dataset=dataset,
+        shuffle=False,
+        num_replicas=2,
+        rank=1,
+        samples_per_gpu=2)
+    dataloader = DataLoader(
+        dataset=dataset, num_workers=0, sampler=sampler, batch_size=2)
+    dataloader_iter = iter(dataloader)
+    for i in range(5):
+        data = next(dataloader_iter)
+        assert torch.allclose(data['img_metas']['idx'], torch.tensor([1, 3]))

--- a/tools/train.py
+++ b/tools/train.py
@@ -134,6 +134,8 @@ def main():
 
     # The flag is used to determine whether it is omnisource training
     cfg.setdefault('omnisource', False)
+    # The flag is used to determine whether to use infinite_sampler
+    cfg.setdefault('use_infinite_sampler', False)
 
     # The flag is used to register module's hooks
     cfg.setdefault('module_hooks', [])


### PR DESCRIPTION
Add `InfiniteSampler` and `InfiniteEpochBasedRunner`

The workers of dataloader will re-initialize when the iterator of dataloader is created. InfiniteSampler is designed to avoid these time-consuming operations since the iterator with InfiniteSampler will never reach the end.