### PR TITLE
fix cd wrong dir error

### DIFF
--- a/tools/data/kinetics/rename_classnames.sh
+++ b/tools/data/kinetics/rename_classnames.sh
@@ -26,4 +26,4 @@ ls ./videos_val | while read class; do \
   fi
 done
 
-cd ../../tools/data/${DATASET}/
+cd ../../tools/data/kinetics/


### PR DESCRIPTION
## Motivation

```bash

mmaction2/tools/data/kinetics$ bash rename_classnames.sh kinetics400
We are processing kinetics400
rename_classnames.sh: line 29: cd: ../../tools/data/kinetics400/: No such file or directory

```

## Modification

```shell
# Line 29
cd ../../tools/data/kinetics/

```
