### PR TITLE
[Update] High-level APIs for testing a video and rawframes not working

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -152,7 +152,7 @@ model = init_recognizer(config_file, checkpoint_file, device=device)
 # test a single video and show the result:
 video = 'demo/demo.mp4'
 labels = 'tools/data/kinetics/label_map_k400.txt'
-results = inference_recognizer(model, video, labels)
+results = inference_recognizer(model, video)
 
 # show the results
 labels = open('tools/data/kinetics/label_map_k400.txt').readlines()
@@ -180,12 +180,12 @@ device = 'cuda:0' # or 'cpu'
 device = torch.device(device)
 
  # build the model from a config file and a checkpoint file
-model = init_recognizer(config_file, checkpoint_file, device=device, use_frames=True)
+model = init_recognizer(config_file, checkpoint_file, device=device)
 
 # test rawframe directory of a single video and show the result:
 video = 'SOME_DIR_PATH/'
 labels = 'tools/data/kinetics/label_map_k400.txt'
-results = inference_recognizer(model, video, labels, use_frames=True)
+results = inference_recognizer(model, video)
 
 # show the results
 labels = open('tools/data/kinetics/label_map_k400.txt').readlines()
@@ -218,7 +218,7 @@ model = init_recognizer(config_file, checkpoint_file, device=device)
 # test url of a single video and show the result:
 video = 'https://www.learningcontainer.com/wp-content/uploads/2020/05/sample-mp4-file.mp4'
 labels = 'tools/data/kinetics/label_map_k400.txt'
-results = inference_recognizer(model, video, labels)
+results = inference_recognizer(model, video)
 
 # show the results
 labels = open('tools/data/kinetics/label_map_k400.txt').readlines()


### PR DESCRIPTION
## Motivation

The test examples in [High-level APIs for testing a video and rawframes](https://mmaction2.readthedocs.io/en/latest/getting_started.html#high-level-apis-for-testing-a-video-and-rawframes) don't work, which is caused by the wrong argument `labels` passed to `inference_recognizer`. The declaration of `inference_recognizer` is `def inference_recognizer(model, video, outputs=None, as_tensor=True, **kwargs)`, and the argument  `outputs` is names of layers whose outputs need to be returned not the filepath of the labels.

## Modification

I remove the argument `labels` passed to `inference_recognizer` and since the argument `use_frames` in `init_recognizer` is deprecated PR #1191, I remove it too.
