### PR TITLE
[Fix] Fix the log error when `IterBasedRunner` is used 

### DIFF
--- a/mmaction/apis/train.py
+++ b/mmaction/apis/train.py
@@ -216,7 +216,7 @@ def train_model(model,
         val_dataloader = build_dataloader(val_dataset, **dataloader_setting)
         eval_hook = DistEvalHook(val_dataloader, **eval_cfg) if distributed \
             else EvalHook(val_dataloader, **eval_cfg)
-        runner.register_hook(eval_hook)
+        runner.register_hook(eval_hook, priority='LOW')
 
     if cfg.resume_from:
         runner.resume(cfg.resume_from)


### PR DESCRIPTION
## Motivation
To be short, if the priority of EvalHook is higher than IterTimerHook, it will cause KeyError: 'data_time'
This PR is based on (https://github.com/open-mmlab/mmdetection/pull/5882, https://github.com/open-mmlab/mmsegmentation/pull/766), where details can be found.

## Modification
Set the priority of `EvalHook` to `LOW` 