### PR TITLE
fix url in config tutorial when talking about Config File Structure

### DIFF
--- a/docs/tutorials/1_config.md
+++ b/docs/tutorials/1_config.md
@@ -51,7 +51,7 @@ For example, if some modification is made base on TSN, users may first inherit t
 
 If you are building an entirely new method that does not share the structure with any of the existing methods, you may create a folder under `configs/TASK`.
 
-Please refer to [mmcv](https://mmcv.readthedocs.io/en/latest/utils.html#config) for detailed documentation.
+Please refer to [mmcv](https://mmcv.readthedocs.io/en/latest/understand_mmcv/config.html) for detailed documentation.
 
 ## Config File Naming Convention
 

--- a/docs_zh_CN/tutorials/1_config.md
+++ b/docs_zh_CN/tutorials/1_config.md
@@ -53,7 +53,7 @@ MMAction2 提供的所有配置文件都放置在 `$MMAction2/configs` 文件夹
 
 如果用户想实现一个独立于任何一个现有的方法结构的新方法，则需要像 `configs/recognition`, `configs/detection` 等一样，在 `configs/TASK` 中建立新的文件夹。
 
-更多详细内容，请参考 [mmcv](https://mmcv.readthedocs.io/en/latest/utils.html#config)。
+更多详细内容，请参考 [mmcv](https://mmcv.readthedocs.io/en/latest/understand_mmcv/config.html)。
 
 ## 配置文件命名规则
 


### PR DESCRIPTION
## Motivation

The origin url in config tutorial is 404 now. I think mmcv has updated the new url, so i replace them in both en and zh_CN files.

## Modification

in both en and zh_CN config tutorial files
