### PR TITLE
Fix issues in audio module

### DIFF
--- a/docs/data_preparation.md
+++ b/docs/data_preparation.md
@@ -134,7 +134,7 @@ python tools/data/extract_audio.py ${ROOT} ${DST_ROOT} [--ext ${EXT}] [--num-wor
 
 - `ROOT`: The root directory of the videos.
 - `DST_ROOT`: The destination root directory of the audios.
-- `EXT`: Extension of the video files. e.g., `.mp4`.
+- `EXT`: Extension of the video files. e.g., `mp4`.
 - `N_WORKERS`: Number of processes to be used.
 
 After extracting audios, you are free to decode and generate the spectrogram on-the-fly such as [this](/configs/audio_recognition/tsn_r50_64x1x1_kinetics400_audio.py). As for the annotations, you can directly use those of the rawframes as long as you keep the relative position of audio files same as the rawframes directory. However, extracting spectrogram on-the-fly is slow and bad for prototype iteration. Therefore, we also provide a script (and many useful tools to play with) for you to generation spectrogram off-line.
@@ -147,7 +147,7 @@ python tools/data/build_audio_features.py ${AUDIO_HOME_PATH} ${SPECTROGRAM_SAVE_
 
 - `AUDIO_HOME_PATH`: The root directory of the audio files.
 - `SPECTROGRAM_SAVE_PATH`: The destination root directory of the audio features.
-- `EXT`: Extension of the audio files. e.g., `.m4a`.
+- `EXT`: Extension of the audio files. e.g., `m4a`.
 - `N_WORKERS`: Number of processes to be used.
 - `PART`: Determines how many parts to be splited and which part to run. e.g., `2/5` means splitting all files into 5-fold and executing the 2nd part. This is useful if you have several machines.
 

--- a/docs_zh_CN/data_preparation.md
+++ b/docs_zh_CN/data_preparation.md
@@ -135,7 +135,7 @@ python tools/data/extract_audio.py ${ROOT} ${DST_ROOT} [--ext ${EXT}] [--num-wor
 
 - `ROOT`: 视频的根目录。
 - `DST_ROOT`: 存放生成音频的根目录。
-- `EXT`: 视频的后缀名，如 `.mp4`。
+- `EXT`: 视频的后缀名，如 `mp4`。
 - `N_WORKERS`: 使用的进程数量。
 
 成功提取出音频后，用户可参照 [配置文件](/configs/audio_recognition/tsn_r50_64x1x1_kinetics400_audio.py) 在线解码并生成梅尔频谱。如果音频文件的目录结构与帧文件夹一致，用户可以直接使用帧数据所用的标注文件作为音频数据的标注文件。在线解码的缺陷在于速度较慢，因此，MMAction2 也提供如下脚本用于离线地生成梅尔频谱。
@@ -148,7 +148,7 @@ python tools/data/build_audio_features.py ${AUDIO_HOME_PATH} ${SPECTROGRAM_SAVE_
 
 - `AUDIO_HOME_PATH`: 音频文件的根目录。
 - `SPECTROGRAM_SAVE_PATH`: 存放生成音频特征的根目录。
-- `EXT`: 音频的后缀名，如 `.m4a`。
+- `EXT`: 音频的后缀名，如 `m4a`。
 - `N_WORKERS`: 使用的进程数量。
 - `PART`: 将完整的解码任务分为几部分并执行其中一份。如 `2/5` 表示将所有待解码数据分成 5 份，并对其中的第 2 份进行解码。这一选项在用户有多台机器时发挥作用。
 

--- a/tools/data/build_audio_features.py
+++ b/tools/data/build_audio_features.py
@@ -299,8 +299,7 @@ if __name__ == '__main__':
 
     files = glob.glob(
         # osp.join(args.audio_home_path, '*/' * args.level, '*' + args.ext)
-        args.audio_home_path + '/*' * args.level + '.' + args.ext
-    )
+        args.audio_home_path + '/*' * args.level + '.' + args.ext)
     print(f'found {len(files)} files.')
     files = sorted(files)
     if args.part is not None:

--- a/tools/data/build_audio_features.py
+++ b/tools/data/build_audio_features.py
@@ -290,7 +290,7 @@ if __name__ == '__main__':
     parser.add_argument('audio_home_path', type=str)
     parser.add_argument('spectrogram_save_path', type=str)
     parser.add_argument('--level', type=int, default=1)
-    parser.add_argument('--ext', default='.m4a')
+    parser.add_argument('--ext', default='m4a')
     parser.add_argument('--num-workers', type=int, default=4)
     parser.add_argument('--part', type=str, default='1/1')
     args = parser.parse_args()
@@ -298,7 +298,9 @@ if __name__ == '__main__':
     mmcv.mkdir_or_exist(args.spectrogram_save_path)
 
     files = glob.glob(
-        osp.join(args.audio_home_path, '*/' * args.level, '*' + args.ext))
+        # osp.join(args.audio_home_path, '*/' * args.level, '*' + args.ext)
+        args.audio_home_path + '/*' * args.level + '.' + args.ext
+    )
     print(f'found {len(files)} files.')
     files = sorted(files)
     if args.part is not None:

--- a/tools/data/extract_audio.py
+++ b/tools/data/extract_audio.py
@@ -18,7 +18,7 @@ def extract_audio_wav(line):
     try:
         if osp.exists(f'{dst_dir}/{video_id}.wav'):
             return
-        cmd = f'ffmpeg -i ./{line}  -map 0:a  -y {dst_dir}/{video_id}.wav'
+        cmd = f'ffmpeg -i {line}  -map 0:a  -y {dst_dir}/{video_id}.wav'
         os.popen(cmd)
     except BaseException:
         with open('extract_wav_err_file.txt', 'a+') as f:
@@ -38,7 +38,7 @@ def parse_args():
         choices=['avi', 'mp4', 'webm'],
         help='video file extensions')
     parser.add_argument(
-        '--num-worker', type=int, default=8, help='number of workers')
+        '--num-workers', type=int, default=8, help='number of workers')
     args = parser.parse_args()
 
     return args


### PR DESCRIPTION
all fixes happen in file `tools/data/extract_audio.py` and `tools/data/build_audio_features.py`

1. use the same `args.ext` style, that is like `mp4` or `wav` without a `.`. This is the same style in videos.
2. for `num-workers`, both use `args.num-workers`, for in original `extract_audio.py` it's `args.num-worker` 
3. change the args of glob() in `build_audio_features.py`, for the origin matching scheme is wrong. You can see #1628 . I change the matching scheme the same with `extract_audio.py` and that is the same with other videos files.
4. There is another issue that i did not mention in Issue 1628, that is in `extract_audio.py` line 21, we should use `{line}` not `./{line}` to get the right video path for extracting audio.
5. Fix expressions in tutorial.md both in en and zh_CN for better understanding.
Hope i don't make other new mistakes for you. 😸 