### PR TITLE
Fix a typo in "extract_audio.py": args.num_worker -> args.num_workers

### DIFF
--- a/tools/data/extract_audio.py
+++ b/tools/data/extract_audio.py
@@ -57,5 +57,5 @@ if __name__ == '__main__':
     print('Total number of videos extracted finished: ',
           len(done_fullpath_list))
 
-    pool = Pool(args.num_worker)
+    pool = Pool(args.num_workers)
     pool.map(extract_audio_wav, fullpath_list)


### PR DESCRIPTION
## Motivation

Fix a typoe in the "extract_audio.py" file.

## Modification

In the "extract_audio.py" file, the argument `--num-worker` was changed to `--num-workers` but `args.num_worker` wasn't changed accordingly. In this PR, `args.num_worker` is changed to `args.num_workers` to avoid errors.

## BC-breaking (Optional)

No
