### PR TITLE
Wild backbones [demo]

### DIFF
--- a/mmaction/models/__init__.py
+++ b/mmaction/models/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from .wild_backbones import *
 from .backbones import (C3D, STGCN, X3D, MobileNetV2, MobileNetV2TSM, ResNet,
                         ResNet2Plus1d, ResNet3d, ResNet3dCSN, ResNet3dLayer,
                         ResNet3dSlowFast, ResNet3dSlowOnly, ResNetAudio,

--- a/mmaction/models/wild_backbones/MViT.py
+++ b/mmaction/models/wild_backbones/MViT.py
@@ -1,0 +1,29 @@
+import torch
+
+from mmaction.models.builder import BACKBONES
+
+
+@BACKBONES.register_module()
+class MViT(torch.nn.Module):
+    def __init__(self, model_type="mvit_base_16x4", pretrained=True, flow_input=False):
+        super().__init__()
+        assert model_type in ('mvit_base_16', 'mvit_base_16x4', 'mvit_base_32x3')
+        model = torch.hub.load("facebookresearch/pytorchvideo", model=model_type, pretrained=pretrained)
+        model.head = None
+        self.model = model
+        if flow_input:
+            w = model.patch_embed.patch_model.weight
+            ww = w.mean(dim=1, keepdim=True)
+            ww = torch.cat([ww, ww], dim=1)
+            conv_flow = torch.nn.Conv3d(96, 2, kernel_size=(3, 7, 7), stride=(2, 4, 4), padding=(1, 3, 3))
+            conv_flow.weight = torch.nn.Parameter(ww, requires_grad=True)
+            conv_flow.bias = model.patch_embed.patch_model.bias
+            self.model.patch_embed.patch_model = conv_flow
+
+    def forward(self, x):
+        x = self.model(x)
+        return x[:, 0, :]
+
+    def init_weights(self):
+        """The model is already initialized in the __init__ function"""
+        pass


### PR DESCRIPTION
This PR takes the first step of #1711. Just a demo.

**Motivation**
If we allow wild backbones, the latest models (with code released) can be quickly adopted to mmation2. For examples, the models in pytorchvideo and slowfast.

**Summary**
I implement the MViT backbone in this PR. It's very simple since it's already supported in `torch.hub`. I just make it to be captable with optical flow input.

**Other**
I have also implemented some other models, such as the MViT2 and ViT-3D (VideoMAE). But they are much more complicated. The MViT2 even brings a mini slowfast package. I'd like to share them once the `wild_backbone` idea is adopted.