### PR TITLE
[Fix] fix BC breaking for TSM initialization

### DIFF
--- a/mmaction/models/backbones/resnet_tsm.py
+++ b/mmaction/models/backbones/resnet_tsm.py
@@ -165,6 +165,14 @@ class ResNetTSM(ResNet):
         self.non_local_stages = _ntuple(self.num_stages)(non_local)
         self.non_local_cfg = non_local_cfg
 
+        super().init_weights()
+        if self.is_shift:
+            self.make_temporal_shift()
+        if len(self.non_local_cfg) != 0:
+            self.make_non_local()
+        if self.temporal_pool:
+            self.make_temporal_pool()
+
     def make_temporal_shift(self):
         """Make temporal shift for some layers."""
         if self.temporal_pool:
@@ -284,12 +292,4 @@ class ResNetTSM(ResNet):
                                                  self.non_local_cfg)
 
     def init_weights(self):
-        """Initiate the parameters either from existing checkpoint or from
-        scratch."""
-        super().init_weights()
-        if self.is_shift:
-            self.make_temporal_shift()
-        if len(self.non_local_cfg) != 0:
-            self.make_non_local()
-        if self.temporal_pool:
-            self.make_temporal_pool()
+        pass


### PR DESCRIPTION
## Motivation

The initialization of TSM model will change the network parameters. In the new version of mmengine, test-only mode will not call the initialization function and thus cannot load trained checkpoints.

## Modification

Move the codes in the function `init_weights` from the class `ResNetTSM` to the `__init__` function.

## Checklist

- [x] Pre-commit or other linting tools should be used to fix the potential lint issues.
- [x] The modification should be covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [x] If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
- [x] The documentation should be modified accordingly, like docstring or example tutorials.
