### PR TITLE
[Fix] the wrong url for pertaining models

### DIFF
--- a/configs/detection/ava/slowfast_kinetics_pretrained_r50_8x8x1_20e_ava_rgb.py
+++ b/configs/detection/ava/slowfast_kinetics_pretrained_r50_8x8x1_20e_ava_rgb.py
@@ -170,6 +170,6 @@ work_dir = ('./work_dirs/ava/'
             'slowfast_kinetics_pretrained_r50_8x8x1_20e_ava_rgb')
 load_from = ('https://download.openmmlab.com/mmaction/recognition/slowfast/'
              'slowfast_r50_8x8x1_256e_kinetics400_rgb/'
-             'slowfast_r50_8x8x1_256e_kinetics400_rgb_20200704-73547d2b.pth')
+             'slowfast_r50_8x8x1_256e_kinetics400_rgb_20200716-73547d2b.pth')
 resume_from = None
 find_unused_parameters = False


### PR DESCRIPTION
The url of the pertaining checkpoint in the AVA detection model is invalid. Just fix the url.