### PR TITLE
[Fix] invalid import due to mmdet APIs changed

### DIFF
--- a/mmaction/models/__init__.py
+++ b/mmaction/models/__init__.py
@@ -17,6 +17,7 @@ from .necks import TPN
 from .recognizers import (BaseRecognizer, Recognizer2D, Recognizer3D,
                           RecognizerGCN)
 from .roi_heads import ACRNHead, AVARoIHead, BBoxHeadAVA, SingleRoIExtractor3D
+from .task_modules import MaxIoUAssignerAVA
 from .utils import BaseMiniBatchBlending, CutmixBlending, MixupBlending
 
 __all__ = [
@@ -32,5 +33,5 @@ __all__ = [
     'TimeSformer', 'TimeSformerHead', 'DividedSpatialAttentionWithNorm',
     'DividedTemporalAttentionWithNorm', 'FFNWithNorm', 'ACRNHead',
     'ActionDataPreprocessor', 'BaseMiniBatchBlending', 'CutmixBlending',
-    'MixupBlending', 'AGCN'
+    'MixupBlending', 'AGCN', 'MaxIoUAssignerAVA'
 ]

--- a/mmaction/models/task_modules/assigners/max_iou_assigner_ava.py
+++ b/mmaction/models/task_modules/assigners/max_iou_assigner_ava.py
@@ -3,7 +3,7 @@ import torch
 from torch import Tensor
 
 try:
-    from mmdet.core.bbox import AssignResult, MaxIoUAssigner
+    from mmdet.models.task_modules import AssignResult, MaxIoUAssigner
     from mmdet.registry import TASK_UTILS as MMDET_TASK_UTILS
     mmdet_imported = True
 except (ImportError, ModuleNotFoundError):


### PR DESCRIPTION
## Motivation
Fix some invalid module imports due to mmdet APIs changed.

## Checklist

- [x] Pre-commit or other linting tools should be used to fix the potential lint issues.
- [x] The modification should be covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [x] If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
- [x] The documentation should be modified accordingly, like docstring or example tutorials.
