### PR TITLE
[Refactor] Add ``BaseActionDataset`` and ``label_smoothing``

### DIFF
--- a/mmaction/datasets/__init__.py
+++ b/mmaction/datasets/__init__.py
@@ -1,15 +1,12 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .ava_dataset import AVADataset
+from .base import BaseActionDataset
 from .pose_dataset import PoseDataset
 from .rawframe_dataset import RawframeDataset
 from .transforms import *  # noqa: F401, F403
 from .video_dataset import VideoDataset
-from .base import BaseActionDataset
 
 __all__ = [
-    'VideoDataset',
-    'RawframeDataset',
-    'AVADataset',
-    'PoseDataset',
+    'VideoDataset', 'RawframeDataset', 'AVADataset', 'PoseDataset',
     'BaseActionDataset'
 ]

--- a/mmaction/datasets/__init__.py
+++ b/mmaction/datasets/__init__.py
@@ -4,10 +4,12 @@ from .pose_dataset import PoseDataset
 from .rawframe_dataset import RawframeDataset
 from .transforms import *  # noqa: F401, F403
 from .video_dataset import VideoDataset
+from .base import BaseActionDataset
 
 __all__ = [
     'VideoDataset',
     'RawframeDataset',
     'AVADataset',
     'PoseDataset',
+    'BaseActionDataset'
 ]

--- a/mmaction/datasets/ava_dataset.py
+++ b/mmaction/datasets/ava_dataset.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 from typing import Callable, List, Optional, Union
 
 import numpy as np
-from mmengine.dataset import BaseDataset
 from mmengine.fileio import load
 from mmengine.logging import MMLogger
 from mmengine.utils import check_file_exist
@@ -12,10 +11,11 @@ from mmengine.utils import check_file_exist
 from mmaction.evaluation import read_labelmap
 from mmaction.registry import DATASETS
 from mmaction.utils import ConfigType
+from .base import BaseActionDataset
 
 
 @DATASETS.register_module()
-class AVADataset(BaseDataset):
+class AVADataset(BaseActionDataset):
     """AVA dataset for spatial temporal detection.
 
     Based on official AVA annotation files, the dataset loads raw frames,
@@ -54,7 +54,8 @@ class AVADataset(BaseDataset):
             ``ava_{train, val}_{v2.1, v2.2}.csv``.
         exclude_file (str): Path to the excluded timestamp file like
             ``ava_{train, val}_excluded_timestamps_{v2.1, v2.2}.csv``.
-        pipeline (list): A sequence of data transforms.
+        pipeline (List[Union[dict, ConfigDict, Callable]]): A sequence of
+            data transforms.
         label_file (str): Path to the label file like
             ``ava_action_list_{v2.1, v2.2}.pbtxt`` or
             ``ava_action_list_{v2.1, v2.2}_for_activitynet_2019.pbtxt``.
@@ -75,8 +76,8 @@ class AVADataset(BaseDataset):
         num_classes (int): The number of classes of the dataset. Default: 81.
             (AVA has 80 action classes, another 1-dim is added for potential
             usage)
-        custom_classes (List[int]): A subset of class ids from origin dataset.
-            Please note that 0 should NOT be selected, and ``num_classes``
+        custom_classes (List[int], optional): A subset of class ids from origin
+            dataset. Please note that 0 should NOT be selected, and ``num_classes``
             should be equal to ``len(custom_classes) + 1``.
         data_prefix (dict or ConfigDict): Path to a directory where video
             frames are held. Defaults to ``dict(img='')``.
@@ -129,18 +130,19 @@ class AVADataset(BaseDataset):
             'The value of '
             'person_det_score_thr should in [0, 1]. ')
         self.person_det_score_thr = person_det_score_thr
-        self.num_classes = num_classes
-        self.filename_tmpl = filename_tmpl
-        self.num_max_proposals = num_max_proposals
         self.timestamp_start = timestamp_start
         self.timestamp_end = timestamp_end
-        self.start_index = start_index
-        self.modality = modality
+        self.num_max_proposals = num_max_proposals
+        self.filename_tmpl = filename_tmpl
+
         super().__init__(
             ann_file,
             pipeline=pipeline,
             data_prefix=data_prefix,
             test_mode=test_mode,
+            num_classes=num_classes,
+            start_index=start_index,
+            modality=modality,
             **kwargs)
 
         if self.proposal_file is not None:
@@ -274,12 +276,11 @@ class AVADataset(BaseDataset):
         return data_list
 
     def get_data_info(self, idx: int) -> dict:
+        """Get annotation by index."""
         data_info = super().get_data_info(idx)
         img_key = data_info['img_key']
 
         data_info['filename_tmpl'] = self.filename_tmpl
-        data_info['modality'] = self.modality
-        data_info['start_index'] = self.start_index
         data_info['timestamp_start'] = self.timestamp_start
         data_info['timestamp_end'] = self.timestamp_end
 

--- a/mmaction/datasets/ava_dataset.py
+++ b/mmaction/datasets/ava_dataset.py
@@ -77,8 +77,8 @@ class AVADataset(BaseActionDataset):
             (AVA has 80 action classes, another 1-dim is added for potential
             usage)
         custom_classes (List[int], optional): A subset of class ids from origin
-            dataset. Please note that 0 should NOT be selected, and ``num_classes``
-            should be equal to ``len(custom_classes) + 1``.
+            dataset. Please note that 0 should NOT be selected, and
+            ``num_classes`` should be equal to ``len(custom_classes) + 1``.
         data_prefix (dict or ConfigDict): Path to a directory where video
             frames are held. Defaults to ``dict(img='')``.
         test_mode (bool): Store True when building test or validation dataset.

--- a/mmaction/datasets/base.py
+++ b/mmaction/datasets/base.py
@@ -41,15 +41,15 @@ class BaseActionDataset(BaseDataset, metaclass=ABCMeta):
                  start_index: int = 0,
                  modality: str = 'RGB',
                  **kwargs) -> None:
+        self.multi_class = multi_class
+        self.num_classes = num_classes
+        self.start_index = start_index
+        self.modality = modality
         super().__init__(ann_file,
                          pipeline=pipeline,
                          data_prefix=data_prefix,
                          test_mode=test_mode,
                          **kwargs)
-        self.multi_class = multi_class
-        self.num_classes = num_classes
-        self.start_index = start_index
-        self.modality = modality
 
     def get_data_info(self, idx: int) -> dict:
         """Get annotation by index."""

--- a/mmaction/datasets/base.py
+++ b/mmaction/datasets/base.py
@@ -1,6 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from typing import List, Callable, Union, Optional
 from abc import ABCMeta
+from typing import Callable, List, Optional, Union
 
 import torch
 from mmengine.dataset import BaseDataset
@@ -45,11 +45,12 @@ class BaseActionDataset(BaseDataset, metaclass=ABCMeta):
         self.num_classes = num_classes
         self.start_index = start_index
         self.modality = modality
-        super().__init__(ann_file,
-                         pipeline=pipeline,
-                         data_prefix=data_prefix,
-                         test_mode=test_mode,
-                         **kwargs)
+        super().__init__(
+            ann_file,
+            pipeline=pipeline,
+            data_prefix=data_prefix,
+            test_mode=test_mode,
+            **kwargs)
 
     def get_data_info(self, idx: int) -> dict:
         """Get annotation by index."""

--- a/mmaction/datasets/base.py
+++ b/mmaction/datasets/base.py
@@ -1,0 +1,65 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from typing import List, Callable, Union, Optional
+from abc import ABCMeta
+
+import torch
+from mmengine.dataset import BaseDataset
+
+from mmaction.utils import ConfigType
+
+
+class BaseActionDataset(BaseDataset, metaclass=ABCMeta):
+    """Base class for datasets.
+
+    Args:
+        ann_file (str): Path to the annotation file.
+        pipeline (List[Union[dict, ConfigDict, Callable]]): A sequence of
+            data transforms.
+        data_prefix (dict or ConfigDict, optional): Path to a directory where
+            videos are held. Defaults to None.
+        test_mode (bool): Store True when building test or validation dataset.
+            Defaults to False.
+        multi_class (bool): Determines whether the dataset is a multi-class
+            dataset. Defaults to False.
+        num_classes (int, optional): Number of classes of the dataset, used in
+            multi-class datasets. Defaults to None.
+        start_index (int): Specify a start index for frames in consideration of
+            different filename format. However, when taking videos as input,
+            it should be set to 0, since frames loaded from videos count
+            from 0. Defaults to 0.
+        modality (str): Modality of data. Support ``RGB``, ``Flow``, ``Pose``,
+            ``Audio``. Defaults to ``RGB``.
+    """
+
+    def __init__(self,
+                 ann_file: str,
+                 pipeline: List[Union[dict, Callable]],
+                 data_prefix: Optional[ConfigType] = None,
+                 test_mode: bool = False,
+                 multi_class: bool = False,
+                 num_classes: Optional[int] = None,
+                 start_index: int = 0,
+                 modality: str = 'RGB',
+                 **kwargs) -> None:
+        super().__init__(ann_file,
+                         pipeline=pipeline,
+                         data_prefix=data_prefix,
+                         test_mode=test_mode,
+                         **kwargs)
+        self.multi_class = multi_class
+        self.num_classes = num_classes
+        self.start_index = start_index
+        self.modality = modality
+
+    def get_data_info(self, idx: int) -> dict:
+        """Get annotation by index."""
+        data_info = super().get_data_info(idx)
+        data_info['modality'] = self.modality
+        data_info['start_index'] = self.start_index
+
+        if self.multi_class:
+            onehot = torch.zeros(self.num_classes)
+            onehot[data_info['label']] = 1.
+            data_info['label'] = onehot
+
+        return data_info

--- a/mmaction/datasets/pose_dataset.py
+++ b/mmaction/datasets/pose_dataset.py
@@ -28,7 +28,7 @@ class PoseDataset(BaseActionDataset):
             ``train2``, ``test2``, ``train3``, ``test3``. Defaults to None.
         start_index (int): Specify a start index for frames in consideration of
             different filename format. Defaults to 0.
-        modality (str): Modality of data. Support ``Pose``. Defaults to ``Pose``.
+        modality (str): Modality of data. Defaults to ``Pose``.
     """
 
     def __init__(self,
@@ -40,11 +40,12 @@ class PoseDataset(BaseActionDataset):
                  **kwargs) -> None:
         # split, applicable to ``ucf101`` or ``hmdb51``
         self.split = split
-        super().__init__(ann_file,
-                         pipeline=pipeline,
-                         start_index=start_index,
-                         modality=modality,
-                         **kwargs)
+        super().__init__(
+            ann_file,
+            pipeline=pipeline,
+            start_index=start_index,
+            modality=modality,
+            **kwargs)
 
     def load_data_list(self) -> List[dict]:
         """Load annotation file to get skeleton information."""

--- a/mmaction/datasets/pose_dataset.py
+++ b/mmaction/datasets/pose_dataset.py
@@ -1,16 +1,16 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from typing import Callable, List, Optional, Union
 
-from mmengine.dataset import BaseDataset
 from mmengine.fileio import load
 from mmengine.utils import check_file_exist
 
 from mmaction.registry import DATASETS
 from mmaction.utils import ConfigType
+from .base import BaseActionDataset
 
 
 @DATASETS.register_module()
-class PoseDataset(BaseDataset):
+class PoseDataset(BaseActionDataset):
     """Pose dataset for action recognition.
 
     The dataset loads pose and apply specified transforms to return a
@@ -27,9 +27,8 @@ class PoseDataset(BaseDataset):
             ``UCF`` or ``HMDB``. Allowed choices are ``train1``, ``test1``,
             ``train2``, ``test2``, ``train3``, ``test3``. Defaults to None.
         start_index (int): Specify a start index for frames in consideration of
-            different filename format. Defaults to 1.
-        modality (str): Modality of data. Support ``RGB``, ``Flow``.
-            Defaults to ``Pose``.
+            different filename format. Defaults to 0.
+        modality (str): Modality of data. Support ``Pose``. Defaults to ``Pose``.
     """
 
     def __init__(self,
@@ -39,11 +38,13 @@ class PoseDataset(BaseDataset):
                  start_index: int = 0,
                  modality: str = 'Pose',
                  **kwargs) -> None:
-        # split, applicable to ucf or hmdb
+        # split, applicable to ``ucf101`` or ``hmdb51``
         self.split = split
-        self.start_index = start_index
-        self.modality = modality
-        super().__init__(ann_file, pipeline=pipeline, **kwargs)
+        super().__init__(ann_file,
+                         pipeline=pipeline,
+                         start_index=start_index,
+                         modality=modality,
+                         **kwargs)
 
     def load_data_list(self) -> List[dict]:
         """Load annotation file to get skeleton information."""
@@ -57,10 +58,3 @@ class PoseDataset(BaseDataset):
             data_list = [x for x in data if x[identifier] in split[self.split]]
 
         return data_list
-
-    def get_data_info(self, idx: int) -> dict:
-        data_info = super().get_data_info(idx)
-        data_info['modality'] = self.modality
-        data_info['start_index'] = self.start_index
-
-        return data_info

--- a/mmaction/models/heads/base.py
+++ b/mmaction/models/heads/base.py
@@ -134,15 +134,16 @@ class BaseHead(BaseModule, metaclass=ABCMeta):
             # shape.
             labels = labels.unsqueeze(0)
 
-        if not self.multi_class and cls_scores.size() != labels.size():
+        if cls_scores.size() != labels.size():
             top_k_acc = top_k_accuracy(cls_scores.detach().cpu().numpy(),
                                        labels.detach().cpu().numpy(),
                                        self.topk)
             for k, a in zip(self.topk, top_k_acc):
                 losses[f'top{k}_acc'] = torch.tensor(
                     a, device=cls_scores.device)
-
-        elif self.multi_class and self.label_smooth_eps != 0:
+        if self.label_smooth_eps != 0:
+            if cls_scores.size() != labels.size():
+                labels = F.one_hot(labels, num_classes=self.num_classes)
             labels = ((1 - self.label_smooth_eps) * labels +
                       self.label_smooth_eps / self.num_classes)
 


### PR DESCRIPTION
## Motivation

 - Since there are some common attributes and class funcions shared between different ``dataset`` classes, it's better to abstract a base dataset to simplify some apis.
- ``label_smoothing`` should not only be supported in multi-class cases as sugested in https://github.com/open-mmlab/mmaction2/issues/1639
