### PR TITLE
Add support of TorchVision's Model Registration API on MMAction2

### DIFF
--- a/mmaction/models/recognizers/base.py
+++ b/mmaction/models/recognizers/base.py
@@ -8,6 +8,7 @@ import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.runner import auto_fp16
+from mmcv.utils import digit_version
 
 from .. import builder
 
@@ -55,8 +56,10 @@ class BaseRecognizer(nn.Module, metaclass=ABCMeta):
                 raise ImportError('Please install torchvision to use this '
                                   'backbone.')
             backbone_type = backbone.pop('type')[12:]
-            self.backbone = torchvision.models.__dict__[backbone_type](
-                **backbone)
+            if digit_version(torchvision.__version__) < digit_version('0.14.0a0'):
+                self.backbone = torchvision.models.__dict__[backbone_type](**backbone)
+            else:
+                self.backbone = torchvision.models.get_model(backbone_type, **backbone)
             # disable the classifier
             self.backbone.classifier = nn.Identity()
             self.backbone.fc = nn.Identity()

--- a/mmaction/models/recognizers/base.py
+++ b/mmaction/models/recognizers/base.py
@@ -56,10 +56,13 @@ class BaseRecognizer(nn.Module, metaclass=ABCMeta):
                 raise ImportError('Please install torchvision to use this '
                                   'backbone.')
             backbone_type = backbone.pop('type')[12:]
-            if digit_version(torchvision.__version__) < digit_version('0.14.0a0'):
-                self.backbone = torchvision.models.__dict__[backbone_type](**backbone)
+            if digit_version(
+                    torchvision.__version__) < digit_version('0.14.0a0'):
+                self.backbone = torchvision.models.__dict__[backbone_type](
+                    **backbone)
             else:
-                self.backbone = torchvision.models.get_model(backbone_type, **backbone)
+                self.backbone = torchvision.models.get_model(
+                    backbone_type, **backbone)
             # disable the classifier
             self.backbone.classifier = nn.Identity()
             self.backbone.fc = nn.Identity()


### PR DESCRIPTION
This PR is similar to https://github.com/open-mmlab/mmcv/pull/2246, but doesn't depend on it. We focus on using the new methods introduced by TorchVision's [Model Registration API](https://pytorch.org/blog/easily-list-and-initialize-models-with-new-apis-in-torchvision/).

It adopts the new `torchvision.models.get_model()` method to initialize a model by its name instead of using directly `torchvision.models.__dict__`.

Looking forward to your feedback (see https://github.com/pytorch/vision/issues/6365).