### PR TITLE
[README.md]Fix typos in mmaction dev-1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@
     </sup>
   </div>
 
-[📘Documentation](https://mmaction2.readthedocs.io/en/1.x/) |
-[🛠️Installation](https://mmaction2.readthedocs.io/en/1.x/get_started.html) |
+[📘Documentation](https://mmaction2.readthedocs.io/en/dev-1.x/index.html) |
+[🛠️Installation](https://mmaction2.readthedocs.io/en/dev-1.x/get_started.html#installation) |
 [👀Model Zoo](https://mmaction2.readthedocs.io/en/dev-1.x/modelzoo.html) |
-[🆕Update News](https://mmaction2.readthedocs.io/en/1.x/notes/changelog.html) |
+[🆕Update News](https://mmaction2.readthedocs.io/en/dev-1.x/notes/changelog.html) |
 [🚀Ongoing Projects](https://github.com/open-mmlab/mmaction2/projects) |
 [🤔Reporting Issues](https://github.com/open-mmlab/mmaction2/issues/new/choose)
 
@@ -77,7 +77,7 @@ The master branch works with **PyTorch 1.6+**.
 
 ## Installation
 
-Please refer to [install.md](https://mmaction2.readthedocs.io/en/1.x/get_started.html) for more detailed instructions.
+Please refer to [install.md](https://github.com/open-mmlab/mmaction2/blob/dev-1.x/docs/en/get_started.md) for more detailed instructions.
 
 ## Supported Methods
 


### PR DESCRIPTION
## Motivation

Improve the readme.md of mmaction2 dev-1.x

## Modification
The Link in README.md is wrong.
Fix the link of [📘Documentation](https://mmaction2.readthedocs.io/en/1.x/)  to [📘Documentation](https://mmaction2.readthedocs.io/en/dev-1.x/index.html)
Fix the link of [🛠️Installation](https://mmaction2.readthedocs.io/en/1.x/get_started.html) to [🛠️Installation](https://mmaction2.readthedocs.io/en/dev-1.x/get_started.html#installation)
Fix the link of [🆕Update News](https://mmaction2.readthedocs.io/en/1.x/notes/changelog.html) to [🆕Update News](https://mmaction2.readthedocs.io/en/dev-1.x/notes/changelog.html)
Fix the install.md link in the Installation section of README.md
Fix the link of https://mmaction2.readthedocs.io/en/1.x/get_started.html to https://github.com/open-mmlab/mmaction2/blob/dev-1.x/docs/en/get_started.md

## Checklist

1. Pre-commit or other linting tools should be used to fix the potential lint issues.
2. The modification should be covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation should be modified accordingly, like docstring or example tutorials.
