### PR TITLE
[Fix] fix colab bug

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -3,7 +3,7 @@ dataclasses; python_version == '3.6'
 imgaug
 librosa
 lmdb
-moviepy
+moviepy==1.0.3
 onnx
 onnxruntime
 packaging


### PR DESCRIPTION
## Motivation
[Fix] fix colab bug
this pr fix bug in [issue](https://github.com/open-mmlab/mmaction2/issues/1943)
default moviepy version in colab environment is too low, and not compatible with imageio now.
