### PR TITLE
Upgrade pre commit hooks in dev-1.x

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: ^tests/data/
 repos:
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.8.3
+    rev: 5.0.4
     hooks:
       - id: flake8
   - repo: https://github.com/PyCQA/isort
@@ -9,11 +9,11 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/mirrors-yapf
-    rev: v0.30.0
+    rev: v0.32.0
     hooks:
       - id: yapf
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v4.3.0
     hooks:
       - id: trailing-whitespace
       - id: check-yaml
@@ -44,18 +44,9 @@ repos:
           - mdformat-openmmlab
           - mdformat_frontmatter
           - linkify-it-py
-  # - repo: local
-  #   hooks:
-  #     - id: update-model-index
-  #       name: update-model-index
-  #       description: Collect model information and update model-index.yml
-  #       entry: .dev_scripts/github/update_model_index.py
-  #       additional_dependencies: [mmcv]
-  #       language: python
-  #       files: ^configs/.*\.md$
-  #       require_serial: true
   - repo: https://github.com/open-mmlab/pre-commit-hooks
     rev: v0.2.0
     hooks:
+      - id: check-algo-readme
       - id: check-copyright
-        args: ["mmaction", "tests", "demo", "tools", "--excludes"]
+        args: ["mmaction", "tests", "demo", "tools"]


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily got feedback.
If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The motivation to upgrade some versions of pre-commit hooks to latest is that importlib-metadata v5.0.0 which removed deprecated endpoint breaks the flake8. More details at https://stackoverflow.com/questions/73929564/entrypoints-object-has-no-attribute-get-digital-ocean/73932581#73932581.

## Modification

Upgrade some versions of pre-commit hooks.

## BC-breaking (Optional)

Does the modification introduces changes that break the back-compatibility of this repo?
If so, please describe how it breaks the compatibility and how users should modify their codes to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools should be used to fix the potential lint issues.
2. The modification should be covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation should be modified accordingly, like docstring or example tutorials.
