### PR TITLE
Add flip_label_map for Flip in some configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ If you find this project useful in your research, please consider cite:
 
 ## Contributing
 
-We appreciate all contributions to improve MMAction2. Please refer to [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/1.x/CONTRIBUTING.md) in MMCV for more details about the contributing guideline.
+We appreciate all contributions to improve MMAction2. Please refer to [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/2.x/CONTRIBUTING.md) in MMCV for more details about the contributing guideline.
 
 ## Acknowledgement
 

--- a/configs/recognition/tpn/tpn-tsm_imagenet-pretrained-r50_8xb8-1x1x8-150e_sthv1-rgb.py
+++ b/configs/recognition/tpn/tpn-tsm_imagenet-pretrained-r50_8xb8-1x1x8-150e_sthv1-rgb.py
@@ -8,12 +8,14 @@ data_root_val = 'data/sthv1/rawframes'
 ann_file_train = 'data/sthv1/sthv1_train_list_rawframes.txt'
 ann_file_val = 'data/sthv1/sthv1_val_list_rawframes.txt'
 ann_file_test = 'data/sthv1/sthv1_val_list_rawframes.txt'
+
+sthv1_flip_label_map = {2: 4, 4: 2, 30: 41, 41: 30, 52: 66, 66: 52}
 train_pipeline = [
     dict(type='SampleFrames', clip_len=1, frame_interval=1, num_clips=8),
     dict(type='RawFrameDecode'),
     dict(type='RandomResizedCrop'),
     dict(type='Resize', scale=(224, 224), keep_ratio=False),
-    dict(type='Flip', flip_ratio=0.5),
+    dict(type='Flip', flip_ratio=0.5, flip_label_map=sthv1_flip_label_map),
     dict(type='ColorJitter'),
     dict(type='FormatShape', input_format='NCHW'),
     dict(type='PackActionInputs')

--- a/configs/recognition/tsm/tsm_imagenet-pretrained-r50_8xb16-1x1x16-50e_sthv2-rgb.py
+++ b/configs/recognition/tsm/tsm_imagenet-pretrained-r50_8xb16-1x1x16-50e_sthv2-rgb.py
@@ -4,6 +4,7 @@ model = dict(backbone=dict(num_segments=16), cls_head=dict(num_segments=16))
 
 file_client_args = dict(io_backend='disk')
 
+sthv2_flip_label_map = {86: 87, 87: 86, 93: 94, 94: 93, 166: 167, 167: 166}
 train_pipeline = [
     dict(type='DecordInit', **file_client_args),
     dict(type='SampleFrames', clip_len=1, frame_interval=1, num_clips=16),
@@ -17,7 +18,7 @@ train_pipeline = [
         max_wh_scale_gap=1,
         num_fixed_crops=13),
     dict(type='Resize', scale=(224, 224), keep_ratio=False),
-    dict(type='Flip', flip_ratio=0.5),
+    dict(type='Flip', flip_ratio=0.5, flip_label_map=sthv2_flip_label_map),
     dict(type='FormatShape', input_format='NCHW'),
     dict(type='PackActionInputs')
 ]

--- a/configs/recognition/tsm/tsm_imagenet-pretrained-r50_8xb16-1x1x8-50e_sthv2-rgb.py
+++ b/configs/recognition/tsm/tsm_imagenet-pretrained-r50_8xb16-1x1x8-50e_sthv2-rgb.py
@@ -11,6 +11,7 @@ ann_file_val = 'data/sthv2/sthv2_val_list_videos.txt'
 
 file_client_args = dict(io_backend='disk')
 
+sthv2_flip_label_map = {86: 87, 87: 86, 93: 94, 94: 93, 166: 167, 167: 166}
 train_pipeline = [
     dict(type='DecordInit', **file_client_args),
     dict(type='SampleFrames', clip_len=1, frame_interval=1, num_clips=8),
@@ -24,7 +25,7 @@ train_pipeline = [
         max_wh_scale_gap=1,
         num_fixed_crops=13),
     dict(type='Resize', scale=(224, 224), keep_ratio=False),
-    dict(type='Flip', flip_ratio=0.5),
+    dict(type='Flip', flip_ratio=0.5, flip_label_map=sthv2_flip_label_map),
     dict(type='FormatShape', input_format='NCHW'),
     dict(type='PackActionInputs')
 ]

--- a/configs/recognition/tsn/tsn_imagenet-pretrained-r50_8xb32-1x1x16-50e_sthv2-rgb.py
+++ b/configs/recognition/tsn/tsn_imagenet-pretrained-r50_8xb32-1x1x16-50e_sthv2-rgb.py
@@ -2,6 +2,7 @@ _base_ = ['tsn_imagenet-pretrained-r50_8xb32-1x1x8-50e_sthv2-rgb.py']
 
 file_client_args = dict(io_backend='disk')
 
+sthv2_flip_label_map = {86: 87, 87: 86, 93: 94, 94: 93, 166: 167, 167: 166}
 train_pipeline = [
     dict(type='DecordInit', **file_client_args),
     dict(type='SampleFrames', clip_len=1, frame_interval=1, num_clips=16),
@@ -15,7 +16,7 @@ train_pipeline = [
         max_wh_scale_gap=1,
         num_fixed_crops=13),
     dict(type='Resize', scale=(224, 224), keep_ratio=False),
-    dict(type='Flip', flip_ratio=0.5),
+    dict(type='Flip', flip_ratio=0.5, flip_label_map=sthv2_flip_label_map),
     dict(type='FormatShape', input_format='NCHW'),
     dict(type='PackActionInputs')
 ]

--- a/configs/recognition/tsn/tsn_imagenet-pretrained-r50_8xb32-1x1x8-50e_sthv2-rgb.py
+++ b/configs/recognition/tsn/tsn_imagenet-pretrained-r50_8xb32-1x1x8-50e_sthv2-rgb.py
@@ -14,6 +14,7 @@ ann_file_val = 'data/sthv2/sthv2_val_list_videos.txt'
 
 file_client_args = dict(io_backend='disk')
 
+sthv2_flip_label_map = {86: 87, 87: 86, 93: 94, 94: 93, 166: 167, 167: 166}
 train_pipeline = [
     dict(type='DecordInit', **file_client_args),
     dict(type='SampleFrames', clip_len=1, frame_interval=1, num_clips=8),
@@ -26,7 +27,7 @@ train_pipeline = [
         random_crop=False,
         max_wh_scale_gap=1),
     dict(type='Resize', scale=(224, 224), keep_ratio=False),
-    dict(type='Flip', flip_ratio=0.5),
+    dict(type='Flip', flip_ratio=0.5, flip_label_map=sthv2_flip_label_map),
     dict(type='FormatShape', input_format='NCHW'),
     dict(type='PackActionInputs')
 ]

--- a/docs/en/get_started.md
+++ b/docs/en/get_started.md
@@ -48,6 +48,13 @@ pip install -U openmim
 mim install mmengine 'mmcv>=2.0.0rc1'
 ```
 
+Note that some of the demo scripts in MMAction2 require [MMDetection](https://github.com/open-mmlab/mmdetection) (mmdet)  for human detection, and [MMPose](https://github.com/open-mmlab/mmpose) for pose estimation. If you want to run these demo scripts, you can easily install mmdet and mmpose as dependencies by running:
+
+```shell
+mim install "mmdet>=3.0.0rc5"
+mim install "mmpose>=1.0.0rc0"
+```
+
 **Step 2.** Install MMAction2.
 
 According to your needs, we support two install modes:

--- a/docs/zh_cn/get_started.md
+++ b/docs/zh_cn/get_started.md
@@ -49,6 +49,13 @@ pip install -U openmim
 mim install mmengine 'mmcv>=2.0.0rc1'
 ```
 
+请注意，MMAction2 中的一些推理示例脚本需要使用 [MMDetection](https://github.com/open-mmlab/mmdetection) (mmdet) 检测人体，[MMPose](https://github.com/open-mmlab/mmpose) 进行姿态估计。如果你想要运行这些示例脚本，可以通过以下命令安装 mmdet 和 mmpose:
+
+```shell
+mim install "mmdet>=3.0.0rc5"
+mim install "mmpose>=1.0.0rc0"
+```
+
 **第二步** 安装 MMAction2。
 
 根据你的需要，我们支持两种安装模式：


### PR DESCRIPTION
## Motivation

When using flip in sthv1/sthv2 dataset, a flip label map should be used to avoid introducing noise into the dataset.

## Modification

Just add `flip_label_map` for `Flip` in some configs.


