### PR TITLE
Fix sthv2 dataset annotations preparation document

### DIFF
--- a/tools/data/sthv2/README.md
+++ b/tools/data/sthv2/README.md
@@ -22,6 +22,12 @@ Before we start, please make sure that the directory is located at `$MMACTION2/t
 
 First of all, you have to sign in and download annotations to `$MMACTION2/data/sthv2/annotations` on the official [website](https://developer.qualcomm.com/software/ai-datasets/something-something).
 
+```shell
+cd $MMACTION2/data/sthv2/annotations
+unzip 20bn-something-something-download-package-labels.zip
+find ./labels -name "*.json" -exec sh -c 'cp "$1" "something-something-v2-$(basename $1)"' _ {} \;
+```
+
 ## Step 2. Prepare Videos
 
 Then, you can download all data parts to `$MMACTION2/data/sthv2/` and use the following command to uncompress.

--- a/tools/data/sthv2/README_zh-CN.md
+++ b/tools/data/sthv2/README_zh-CN.md
@@ -22,6 +22,12 @@
 
 首先，用户需要在 [官网](https://20bn.com/datasets/something-something/v2) 完成注册，才能下载标注文件。下载好的标注文件需要放在 `$MMACTION2/data/sthv2/annotations` 文件夹下。
 
+```shell
+cd $MMACTION2/data/sthv2/annotations
+unzip 20bn-something-something-download-package-labels.zip
+find ./labels -name "*.json" -exec sh -c 'cp "$1" "something-something-v2-$(basename $1)"' _ {} \;
+```
+
 ## 步骤 2. 准备视频
 
 之后，用户可将下载好的压缩文件放在 `$MMACTION2/data/sthv2/` 文件夹下，并且使用以下指令进行解压。


### PR DESCRIPTION

## Motivation

The paths of sthv2 dataset's annotation file is hardcoded.
https://github.com/open-mmlab/mmaction2/blob/dbb8f064151a90be647846bcfafb43fd2b523c3f/tools/data/parse_file_list.py#L243-L247
which will fail when user follows the sthv2 dataset preparation document to generate the file list

## Modification

added renaming script to **Step 1. Prepare Annotations** in both `tools/data/sthv2/README.md` and `tools/data/sthv2/README_zh-CN.md`


