### PR TITLE
[fix] specify map_location to cpu when using _load_checkpoint

### DIFF
--- a/mmaction/models/backbones/resnet.py
+++ b/mmaction/models/backbones/resnet.py
@@ -497,7 +497,8 @@ class ResNet(nn.Module):
     def _load_torchvision_checkpoint(self,
                                      logger: mmengine.MMLogger = None) -> None:
         """Initiate the parameters from torchvision pretrained checkpoint."""
-        state_dict_torchvision = _load_checkpoint(self.pretrained)
+        state_dict_torchvision = _load_checkpoint(
+            self.pretrained, map_location='cpu')
         if 'state_dict' in state_dict_torchvision:
             state_dict_torchvision = state_dict_torchvision['state_dict']
 

--- a/mmaction/models/backbones/resnet3d.py
+++ b/mmaction/models/backbones/resnet3d.py
@@ -711,7 +711,7 @@ class ResNet3d(nn.Module):
                 debugging information.
         """
 
-        state_dict_r2d = _load_checkpoint(self.pretrained)
+        state_dict_r2d = _load_checkpoint(self.pretrained, map_location='cpu')
         if 'state_dict' in state_dict_r2d:
             state_dict_r2d = state_dict_r2d['state_dict']
 

--- a/mmaction/models/backbones/resnet3d_slowfast.py
+++ b/mmaction/models/backbones/resnet3d_slowfast.py
@@ -222,7 +222,7 @@ class ResNet3dPathway(ResNet3d):
                 debugging information.
         """
 
-        state_dict_r2d = _load_checkpoint(self.pretrained)
+        state_dict_r2d = _load_checkpoint(self.pretrained, map_location='cpu')
         if 'state_dict' in state_dict_r2d:
             state_dict_r2d = state_dict_r2d['state_dict']
 

--- a/mmaction/models/backbones/timesformer.py
+++ b/mmaction/models/backbones/timesformer.py
@@ -235,7 +235,7 @@ class TimeSformer(nn.Module):
             logger = MMLogger.get_current_instance()
             logger.info(f'load model from: {self.pretrained}')
 
-            state_dict = _load_checkpoint(self.pretrained)
+            state_dict = _load_checkpoint(self.pretrained, map_location='cpu')
             if 'state_dict' in state_dict:
                 state_dict = state_dict['state_dict']
 


### PR DESCRIPTION
## Motivation
[fix] specify map_location to cpu when use _load_checkpoint to avoid load ckpt to cuda:0 for all cuda devices.