### PR TITLE
[Doc] fix outdated links in the documentation

### DIFF
--- a/docs/en/useful_tools.md
+++ b/docs/en/useful_tools.md
@@ -218,7 +218,7 @@ python tools/analysis/eval_metric.py ${CONFIG_FILE} ${RESULT_FILE} [--eval ${EVA
 `tools/analysis/print_config.py` prints the whole config verbatim, expanding all its imports.
 
 ```shell
-python tools/print_config.py ${CONFIG} [-h] [--options ${OPTIONS [OPTIONS...]}]
+python tools/analysis/print_config.py ${CONFIG} [-h] [--options ${OPTIONS [OPTIONS...]}]
 ```
 
 ### Check videos

--- a/docs/zh_cn/useful_tools.md
+++ b/docs/zh_cn/useful_tools.md
@@ -151,7 +151,7 @@ python tools/analysis/eval_metric.py ${CONFIG_FILE} ${RESULT_FILE} [--eval ${EVA
 `tools/analysis/print_config.py` 脚本会解析所有输入变量，并打印完整配置信息。
 
 ```shell
-python tools/print_config.py ${CONFIG} [-h] [--options ${OPTIONS [OPTIONS...]}]
+python tools/analysis/print_config.py ${CONFIG} [-h] [--options ${OPTIONS [OPTIONS...]}]
 ```
 
 ### 检查视频


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily got feedback.
If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The document in `useful_tools.md` contains an error, the folder param `analysis` is missing in the command execution section.

https://github.com/open-mmlab/mmaction2/blob/master/tools/analysis/print_config.py

## Modification

Change the doucument.

## Checklist

1. Pre-commit or other linting tools should be used to fix the potential lint issues.
2. The modification should be covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation should be modified accordingly, like docstring or example tutorials.
