### PR TITLE
[Fix] Fix a bug in `demo_skeleton.py`

### DIFF
--- a/demo/demo_configs/faster-rcnn_r50_fpn_2x_coco_infer.py
+++ b/demo/demo_configs/faster-rcnn_r50_fpn_2x_coco_infer.py
@@ -117,7 +117,7 @@ dataset_type = 'CocoDataset'
 data_root = 'data/coco/'
 file_client_args = dict(backend='disk')
 test_pipeline = [
-    dict(type='mmdet.LoadImageFromFile', file_client_args=file_client_args),
+    dict(type='LoadImageFromFile', file_client_args=file_client_args),
     dict(type='mmdet.Resize', scale=(1333, 800), keep_ratio=True),
     dict(
         type='mmdet.PackDetInputs',


### PR DESCRIPTION
## Motivation
KeyError: 'mmdet.LoadImageFromFile is not in the transform registry. Please check whether the value of `mmdet.LoadImageFromFile` is correct or it was registered as expected. More details can be found at https://mmengine.readthedocs.io/en/latest/advanced_tutorials/config.html#import-the-custom-module'
https://github.com/open-mmlab/mmaction2/issues/2366

## Modification

Fix `demo_skeleton.py ` caused by Registry.
