### PR TITLE
[Fix] Update outdated dependencies of mmcv for downloading fine-gym dataset

### DIFF
--- a/tools/data/gym/download.py
+++ b/tools/data/gym/download.py
@@ -7,7 +7,7 @@ import os
 import ssl
 import subprocess
 
-import mmcv
+import mmengine
 from joblib import Parallel, delayed
 
 ssl._create_default_https_context = ssl._create_unverified_context
@@ -72,7 +72,7 @@ def download_wrapper(youtube_id, output_dir):
 
 def main(input, output_dir, num_jobs=24):
     # Reading and parsing ActivityNet.
-    youtube_ids = mmcv.load(input).keys()
+    youtube_ids = mmengine.load(input).keys()
     # Creates folders where videos will be saved later.
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
@@ -87,7 +87,7 @@ def main(input, output_dir, num_jobs=24):
             for index in youtube_ids)
 
     # Save download report.
-    mmcv.dump(status_list, 'download_report.json')
+    mmengine.dump(status_list, 'download_report.json')
 
 
 if __name__ == '__main__':

--- a/tools/data/gym/download_videos.sh
+++ b/tools/data/gym/download_videos.sh
@@ -3,7 +3,7 @@
 # set up environment
 conda env create -f environment.yml
 source activate gym
-pip install "mmcv<2.0.0"
+pip install mmengine
 pip install --upgrade youtube-dl
 
 DATA_DIR="../../../data/gym"

--- a/tools/data/gym/download_videos.sh
+++ b/tools/data/gym/download_videos.sh
@@ -3,7 +3,7 @@
 # set up environment
 conda env create -f environment.yml
 source activate gym
-pip install mmcv
+pip install "mmcv<2.0.0"
 pip install --upgrade youtube-dl
 
 DATA_DIR="../../../data/gym"

--- a/tools/data/gym/trim_event.py
+++ b/tools/data/gym/trim_event.py
@@ -3,7 +3,7 @@ import os
 import os.path as osp
 import subprocess
 
-import mmcv
+import mmengine
 
 data_root = '../../../data/gym'
 video_root = f'{data_root}/videos'
@@ -15,10 +15,10 @@ event_root = f'{data_root}/events'
 
 videos = os.listdir(video_root)
 videos = set(videos)
-annotation = mmcv.load(anno_file)
+annotation = mmengine.load(anno_file)
 event_annotation = {}
 
-mmcv.mkdir_or_exist(event_root)
+mmengine.mkdir_or_exist(event_root)
 
 for k, v in annotation.items():
     if k + '.mp4' not in videos:
@@ -55,4 +55,4 @@ for k, v in annotation.items():
         if segments is not None:
             event_annotation[event_name] = segments
 
-mmcv.dump(event_annotation, event_anno_file)
+mmengine.dump(event_annotation, event_anno_file)

--- a/tools/data/gym/trim_subaction.py
+++ b/tools/data/gym/trim_subaction.py
@@ -3,7 +3,7 @@ import os
 import os.path as osp
 import subprocess
 
-import mmcv
+import mmengine
 
 data_root = '../../../data/gym'
 anno_root = f'{data_root}/annotations'
@@ -14,9 +14,9 @@ subaction_root = f'{data_root}/subactions'
 
 events = os.listdir(event_root)
 events = set(events)
-annotation = mmcv.load(event_anno_file)
+annotation = mmengine.load(event_anno_file)
 
-mmcv.mkdir_or_exist(subaction_root)
+mmengine.mkdir_or_exist(subaction_root)
 
 for k, v in annotation.items():
     if k + '.mp4' not in events:


### PR DESCRIPTION
## Motivation

The MMCV package now has version 2.0.0, which removes the function `mmcv.load()`, causing the following error when running tools/data/gym/download_videos.sh:

Traceback (most recent call last):                                                                                                                                                                                     
  File "download.py", line 100, in <module>                                                                                                                                                                            
    main(**vars(p.parse_args()))                                                                                                                                                                                       
  File "download.py", line 75, in main                                                                                                                                                                                 
    youtube_ids = mmcv.load(input).keys()                                                                                                                                                                              
AttributeError: module 'mmcv' has no attribute 'load'

## Modification

Changing `pip install mmcv` to `pip install "mmcv<2.0.0"` addresses this problem.

