### PR TITLE
[Fix] Close `FileHandler` in Windows to make the temporary directory can be deleted

### DIFF
--- a/tools/analysis_tools/confusion_matrix.py
+++ b/tools/analysis_tools/confusion_matrix.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import argparse
+import logging
 import tempfile
 
 import torch
@@ -83,6 +84,7 @@ def main():
             classes = runner.test_loop.dataloader.dataset.metainfo.get(
                 'classes')
             cm = runner.test()['confusion_matrix/result']
+            logging.shutdown()
     else:
         predictions = load(args.ckpt_or_result)
         evaluator = Evaluator(ConfusionMatrix())


### PR DESCRIPTION
## Motivation
[Fix] Close `FileHandler` in Windows to make the temporary directory can be deleted