### PR TITLE
[Fix] Fix mismatch when number of people changes

### DIFF
--- a/demo/demo_skeleton.py
+++ b/demo/demo_skeleton.py
@@ -164,8 +164,9 @@ def main():
     keypoint_score = np.zeros((num_frame, num_person, num_keypoint),
                               dtype=np.float16)
     for i, poses in enumerate(pose_results):
-        keypoint[i] = poses['keypoints']
-        keypoint_score[i] = poses['keypoint_scores']
+        num_current_person = len(poses['keypoints'])
+        keypoint[i, :num_current_person] = poses['keypoints']
+        keypoint_score[i, :num_current_person] = poses['keypoint_scores']
 
     fake_anno['keypoint'] = keypoint.transpose((1, 0, 2, 3))
     fake_anno['keypoint_score'] = keypoint_score.transpose((1, 0, 2))


### PR DESCRIPTION
## Motivation

In skeleton-based action recognition demo, arrays are created with dimension num_person, but when fewer people are detected in some frames, the keypoints data is jagged and there's a dimension mismatch error. #2572

## Modification

If there isn't enough keypoints data, only fill the first slots of the array.
