### PR TITLE
[Fix] Dimension Mismatch in 5D Tensor Permute Operation in visualization_hook.py

### DIFF
--- a/mmaction/engine/hooks/visualization_hook.py
+++ b/mmaction/engine/hooks/visualization_hook.py
@@ -78,29 +78,33 @@ class VisualizationHook(Hook):
         for sample_id in range(first_sample_id, end_idx, self.interval):
             video = videos[sample_id - start_idx]
             # move channel to the last
-            video = video.permute(1, 2, 3, 0).numpy().astype('uint8')
+            #video = video.permute(1, 2, 3, 0).numpy().astype('uint8')
+            for i in range(video.shape[0]):
+                single_video = video[i].permute(1, 2, 3, 0).numpy().astype('uint8')
+                data_sample = data_samples[sample_id - start_idx]
+                if 'filename' in data_sample:
+                    # osp.basename works on different platforms even file clients.
+                    sample_name = osp.basename(data_sample.get('filename'))
+                elif 'frame_dir' in data_sample:
+                    sample_name = osp.basename(data_sample.get('frame_dir'))
+                else:
+                    sample_name = str(sample_id)
 
-            data_sample = data_samples[sample_id - start_idx]
-            if 'filename' in data_sample:
-                # osp.basename works on different platforms even file clients.
-                sample_name = osp.basename(data_sample.get('filename'))
-            elif 'frame_dir' in data_sample:
-                sample_name = osp.basename(data_sample.get('frame_dir'))
-            else:
-                sample_name = str(sample_id)
+                draw_args = self.draw_args
+                if 'show' in draw_args:
+                    del draw_args['show']
+                print(draw_args)
+                if self.out_dir is not None:
+                    draw_args['out_path'] = self.file_client.join_path(
+                        self.out_dir, f'{sample_name}_{step}')
 
-            draw_args = self.draw_args
-            if self.out_dir is not None:
-                draw_args['out_path'] = self.file_client.join_path(
-                    self.out_dir, f'{sample_name}_{step}')
-
-            self._visualizer.add_datasample(
-                sample_name,
-                video=video,
-                data_sample=data_sample,
-                step=step,
-                **self.draw_args,
-            )
+                self._visualizer.add_datasample(
+                    sample_name,
+                    video=single_video,
+                    data_sample=data_sample,
+                    step=step,
+                    **self.draw_args,
+                )
 
     def after_val_iter(self, runner: Runner, batch_idx: int, data_batch: dict,
                        outputs: Sequence[ActionDataSample]) -> None:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily got feedback.
If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The following code in _draw_datasample function of visualization_hook.py attempts to permute a video tensor, which leads to a dimension mismatch error.

```python
video = video.permute(1, 2, 3, 0).numpy().astype('uint8')
```
Executing this line throws the following error message:
```python
RuntimeError: permute(sparse_coo): number of dimensions in the tensor input does not match the length of the desired ordering of dimensions i.e. input.dim() = 5 is not equal to len(dims) = 4
```

## Modification
Modified the video tensor manipulation logic to handle each video individually. This avoids the dimension mismatch issue.
- Iterated through each video.
- Used 'permute' and 'astype' to rearrange and typecast each frame.

```python
# Code snippet showing the changes
for i in range(video.shape[0]):
    single_video = video[i].permute(1, 2, 3, 0).numpy().astype('uint8')
    # rest of the code
```

## BC-breaking (Optional)

Does the modification introduces changes that break the back-compatibility of this repo?
No

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.
No

## Checklist

1. Pre-commit or other linting tools should be used to fix the potential lint issues.
2. The modification should be covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation should be modified accordingly, like docstring or example tutorials.