### PR TITLE
Correct the Conference of C3D.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,17 +59,17 @@ English | [简体中文](/README_zh-CN.md)
 ## 📄 Table of Contents
 
 - [📄 Table of Contents](#-table-of-contents)
-- [🥳 🚀 What's New](#--whats-new-)
-- [📖 Introduction](#-introduction-)
-- [🎁 Major Features](#-major-features-)
-- [🛠️ Installation](#️-installation-)
-- [👀 Model Zoo](#-model-zoo-)
-- [👨‍🏫 Get Started](#-get-started-)
-- [🎫 License](#-license-)
-- [🖊️ Citation](#️-citation-)
-- [🙌 Contributing](#-contributing-)
-- [🤝 Acknowledgement](#-acknowledgement-)
-- [🏗️ Projects in OpenMMLab](#️-projects-in-openmmlab-)
+- [🥳 🚀 What's New 🔝](#--whats-new-)
+- [📖 Introduction 🔝](#-introduction-)
+- [🎁 Major Features 🔝](#-major-features-)
+- [🛠️ Installation 🔝](#️-installation-)
+- [👀 Model Zoo 🔝](#-model-zoo-)
+- [👨‍🏫 Get Started 🔝](#-get-started-)
+- [🎫 License 🔝](#-license-)
+- [🖊️ Citation 🔝](#️-citation-)
+- [🙌 Contributing 🔝](#-contributing-)
+- [🤝 Acknowledgement 🔝](#-acknowledgement-)
+- [🏗️ Projects in OpenMMLab 🔝](#️-projects-in-openmmlab-)
 
 ## 🥳 🚀 What's New [🔝](#-table-of-contents)
 
@@ -149,7 +149,7 @@ Results and models are available in the [model zoo](https://mmaction2.readthedoc
     <td colspan="5" style="font-weight:bold;">Action Recognition</td>
   </tr>
   <tr>
-    <td><a href="https://github.com/open-mmlab/mmaction2/blob/main/configs/recognition/c3d/README.md">C3D</a> (CVPR'2014)</td>
+    <td><a href="https://github.com/open-mmlab/mmaction2/blob/main/configs/recognition/c3d/README.md">C3D</a> (ICCV'2015)</td>
     <td><a href="https://github.com/open-mmlab/mmaction2/blob/main/configs/recognition/tsn/README.md">TSN</a> (ECCV'2016)</td>
     <td><a href="https://github.com/open-mmlab/mmaction2/blob/main/configs/recognition/i3d/README.md">I3D</a> (CVPR'2017)</td>
     <td><a href="https://github.com/open-mmlab/mmaction2/blob/main/configs/recognition/c2d/README.md">C2D</a> (CVPR'2018)</td>

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -59,18 +59,18 @@
 ## 📄 目录
 
 - [📄 目录](#-目录)
-- [🥳 🚀 最新进展](#--最新进展-)
-- [📖 简介](#-简介-)
-- [🎁 主要功能](#-主要功能-)
-- [🛠️ 安装](#️-安装-)
-- [👀 模型库](#-模型库-)
-- [👨‍🏫 新手入门](#-新手入门-)
-- [🎫 许可证](#-许可证-)
-- [🖊️ 引用](#️-引用-)
-- [🙌 参与贡献](#-参与贡献-)
-- [🤝 致谢](#-致谢-)
-- [🏗️ OpenMMLab 的其他项目](#️-openmmlab-的其他项目-)
-- [❤️ 欢迎加入 OpenMMLab 社区](#️-欢迎加入-openmmlab-社区-)
+- [🥳 🚀 最新进展 🔝](#--最新进展-)
+- [📖 简介 🔝](#-简介-)
+- [🎁 主要功能 🔝](#-主要功能-)
+- [🛠️ 安装 🔝](#️-安装-)
+- [👀 模型库 🔝](#-模型库-)
+- [👨‍🏫 新手入门 🔝](#-新手入门-)
+- [🎫 许可证 🔝](#-许可证-)
+- [🖊️ 引用 🔝](#️-引用-)
+- [🙌 参与贡献 🔝](#-参与贡献-)
+- [🤝 致谢 🔝](#-致谢-)
+- [🏗️ OpenMMLab 的其他项目 🔝](#️-openmmlab-的其他项目-)
+- [❤️ 欢迎加入 OpenMMLab 社区 🔝](#️-欢迎加入-openmmlab-社区-)
 
 ## 🥳 🚀 最新进展 [🔝](#-table-of-contents)
 
@@ -150,7 +150,7 @@ pip install -v -e .
     <td colspan="5" style="font-weight:bold;">行为识别</td>
   </tr>
   <tr>
-    <td><a href="https://github.com/open-mmlab/mmaction2/blob/main/configs/recognition/c3d/README.md">C3D</a> (CVPR'2014)</td>
+    <td><a href="https://github.com/open-mmlab/mmaction2/blob/main/configs/recognition/c3d/README.md">C3D</a> (ICCV'2015)</td>
     <td><a href="https://github.com/open-mmlab/mmaction2/blob/main/configs/recognition/tsn/README.md">TSN</a> (ECCV'2016)</td>
     <td><a href="https://github.com/open-mmlab/mmaction2/blob/main/configs/recognition/i3d/README.md">I3D</a> (CVPR'2017)</td>
     <td><a href="https://github.com/open-mmlab/mmaction2/blob/main/configs/recognition/c2d/README.md">C2D</a> (CVPR'2018)</td>


### PR DESCRIPTION
## Motivation

I found the conference information of C3D in model zoo is incorrect, so I wanna correct it.

## Modification

I modify the coference of C3D from CVPR2014 to ICCV2015 in both README.md and README_zh-CN.md according to this [link](https://openaccess.thecvf.com/content_iccv_2015/html/Tran_Learning_Spatiotemporal_Features_ICCV_2015_paper.html)

## BC-breaking (Optional)

Does the modification introduces changes that break the back-compatibility of this repo?
No


## Checklist

1. Pre-commit or other linting tools should be used to fix the potential lint issues.
2. The modification should be covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation should be modified accordingly, like docstring or example tutorials.
