### PR TITLE
Bugfix: Define 'args' variable or pass it as a parameter in resize_videos function

### DIFF
--- a/tools/data/resize_videos.py
+++ b/tools/data/resize_videos.py
@@ -95,6 +95,7 @@ def parse_args():
 
 args = parse_args()
 
+
 if __name__ == '__main__':
 
     if not osp.isdir(args.out_dir):

--- a/tools/data/resize_videos.py
+++ b/tools/data/resize_videos.py
@@ -93,9 +93,9 @@ def parse_args():
 
     return args
 
+args = parse_args()
 
 if __name__ == '__main__':
-    args = parse_args()
 
     if not osp.isdir(args.out_dir):
         print(f'Creating folder: {args.out_dir}')


### PR DESCRIPTION
## Motivation

This submission aims to fix the 'NameError: name 'args' is not defined' error that occurs in the 'resize_videos' function under tools\data\resize_videos.py.

## Modification
I have moved the definition of args = parse_args() outside of the if __name__ == '__main__': block, making it a global variable. 

