### PR TITLE
[Chore] Update .mailmap to fix contributor attribution

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,4 @@
+Dai-Wenxun <wxDai2001@gmail.com> wxDai <daiwenxun@pjlab.org.cn>
+Dai-Wenxun <wxDai2001@gmail.com> daiwenxun.vendor <daiwenxun@pjlab.org.cn>
+Dai-Wenxun <wxDai2001@gmail.com> wxDai <wxDai2001@gmail.com>
+Dai-Wenxun <wxDai2001@gmail.com> Dai-Wenxun <wxdai2001@gmail.com>


### PR DESCRIPTION
This PR updates `.mailmap` to fix contributor attribution for historical commits made with an old, now inaccessible company email address.

The mapping consolidates multiple author identities that belong to the same contributor into the current GitHub-linked email, so contribution statistics can be correctly attributed after GitHub refreshes repository metadata.
